### PR TITLE
Eliminate common subexpressions in the generated field code

### DIFF
--- a/src/analytic/abc.jl
+++ b/src/analytic/abc.jl
@@ -13,7 +13,7 @@ module ABC
     using RecipesBase
 
     import ..ElectromagneticFields
-    import ..ElectromagneticFields: CartesianEquilibrium, code
+    import ..ElectromagneticFields: CartesianEquilibrium, code, code_arguments
     import ..ElectromagneticFields: A₁, A₂, A₃
     import ..AnalyticCartesianField: X, Y, Z
 
@@ -38,8 +38,9 @@ module ABC
         ABCEquilibrium(a, b, c)
     end
 
-    macro code(a=DEFAULT_A, b=DEFAULT_B, c=DEFAULT_C)
-        code(init(a, b, c); escape=true)
+    macro code(args...)
+        parameters, options = code_arguments(args)
+        code(init(parameters...); escape=true, options...)
     end
 
     function Base.show(io::IO, equ::ABCEquilibrium)

--- a/src/analytic/analytic_equilibrium.jl
+++ b/src/analytic/analytic_equilibrium.jl
@@ -564,6 +564,36 @@ fnesc(name, escape) = escape ? esc(name) : name
 
 
 """
+    code_arguments(args)
+
+Split the arguments a `@code` macro was called with into the equilibrium's parameters and the options
+destined for [`code`](@ref), returned as `(parameters, options)`.
+
+Macros cannot take keyword arguments, so an option is written as `key = value` among the arguments —
+`@code cse = false` or `@code(R₀, B₀, q₀, cse = false)`. A `; key = value` tail is accepted too.
+"""
+function code_arguments(args)
+    parameters = Any[]
+    options = Pair{Symbol,Any}[]
+
+    for arg in args
+        if arg isa Expr && arg.head === :parameters
+            # a `; key = value` tail, which the parser hands over as the first argument
+            for kw in arg.args
+                push!(options, kw.args[1] => kw.args[2])
+            end
+        elseif arg isa Expr && arg.head === :(=) && arg.args[1] isa Symbol
+            push!(options, arg.args[1] => arg.args[2])
+        else
+            push!(parameters, arg)
+        end
+    end
+
+    (parameters, options)
+end
+
+
+"""
     code(equ, pert = ZeroPerturbation(); export_parameters = true, escape = false, output = 0, cse = true)
 
 Generate code for evaluating analytic equilibria: an `Expr` defining the field functions of `equ`,
@@ -576,7 +606,10 @@ which `@code` splices into the calling module and [`load_equilibrium`](@ref) eva
   This is on by default and is value-preserving to the last bit — subexpressions are named, never
   rewritten — but the generated code is easier to read against a paper with it off. It matters:
   SymEngine shares nothing, so `db₁dx₁` of the ITER Solov'ev equilibrium with an X-point contains
-  108 separate evaluations of `log(x₁)` without it, and is 6.8 times slower.
+  108 separate evaluations of `log(ξ₁)` without it, and is 6.8 times slower.
+
+The `@code` macros take these as `key = value` arguments, after the equilibrium's parameters:
+`ThetaPinch.@code(B₀, cse = false)`, or just `ThetaPinch.@code cse = false` for the defaults.
 """
 function code(equ, pert=ZeroPerturbation(); export_parameters=true, escape=false, output=0, cse=true)
 
@@ -772,7 +805,13 @@ end
 
 
 """
-Evaluate functions for evaluating analytic equilibria.
+    load_equilibrium(equ, pert = ZeroPerturbation(); target_module = Main, output = 0, cse = true)
+
+Evaluate functions for evaluating analytic equilibria: generate the field functions of `equ` with
+[`code`](@ref) and evaluate them into `target_module`.
+
+`output` and `cse` are passed on to [`code`](@ref) — in particular `cse = false` emits every repeated
+subexpression in full, which is slower but easier to read against a paper.
 """
 function load_equilibrium(equ, pert=ZeroPerturbation(); target_module=Main, output=0, cse=true)
     equ_code = code(equ, pert; output=output, cse=cse)

--- a/src/analytic/analytic_equilibrium.jl
+++ b/src/analytic/analytic_equilibrium.jl
@@ -460,13 +460,125 @@ function replace_expr!(e, old, new)
 end
 
 
+#
+# Common subexpression elimination for the generated field code.
+#
+# `convert(Expr, ::Basic)` writes out SymEngine's expanded tree verbatim, and SymEngine shares
+# nothing: a subexpression common to fifty branches of `∂ⱼ(Bᵢ / sqrt(gᵏˡBₖBₗ))` is emitted fifty
+# times. On the ITER Solov'ev equilibrium with an X-point, whose flux function carries `x² log x`
+# terms, `db₁dx₁` comes out as 1905 statements containing 108 separate evaluations of `log(x₁)` and
+# 557 powers, and `d²b₁dx₁dx₁` as 6231 statements with 367 logs. Naming each distinct subexpression
+# once takes those to 83 ns and 137 ns from 566 ns and 1749 ns.
+#
+# This only *names* subexpressions. It never reassociates, never reorders an operand, never folds a
+# constant — so every generated function returns bit-for-bit what it returned before, which
+# `test/test_analytic.jl` asserts for every function of every equilibrium.
+#
+# Implemented by hash-consing rather than by hashing whole `Expr`s: a node is keyed by its head and
+# the integer ids of its arguments, so no subtree is ever hashed or printed as a whole and the pass
+# is linear in the size of the expression. The naive version — `Dict{Expr,Int}` keyed by the
+# subtrees themselves, sorted by printed length — is quadratic and does not finish on the Solov'ev
+# second derivatives.
+#
+# Ids are handed out in post-order, so a node's arguments always have smaller ids than the node.
+# Emitting the temporaries in increasing id order is therefore a topological order by construction,
+# and needs no sort.
+#
+
+function _hashcons(body)
+    ids = Dict{Any,Int}()
+    keys = Vector{Any}()
+    counts = Vector{Int}()
+
+    function visit(e)
+        key = if e isa Expr && e.head === :call
+            # The head, then one id per argument. A `Vector{Any}` rather than a tuple so that the
+            # arity is not part of the type and the dictionary stays concrete.
+            Any[e.args[1]; Int[visit(a) for a in @view e.args[2:end]]]
+        else
+            # Leaves — symbols and numeric literals — carry their type, because `isequal(1, 1.0)`
+            # is true and the two must not be conflated into one temporary.
+            (typeof(e), e)
+        end
+
+        id = get(ids, key, 0)
+
+        if id == 0
+            push!(keys, key)
+            push!(counts, 0)
+            id = length(keys)
+            ids[key] = id
+        end
+
+        counts[id] += 1
+        id
+    end
+
+    (keys, counts, visit(body))
+end
+
+"""
+    eliminate_common_subexpressions(body::Expr; prefix = "_cse")
+
+Rewrite a generated function body so that every repeated subexpression is evaluated once and read
+from a local afterwards. Returns a `begin ... end` block whose value is that of `body`, and whose
+locals are named `prefix * n`.
+
+Value-preserving to the last bit: subexpressions are named, not rewritten.
+"""
+function eliminate_common_subexpressions(body::Expr; prefix="_cse")
+    keys, counts, root = _hashcons(body)
+
+    name = Vector{Any}(undef, length(keys))
+    stmts = Any[]
+    n = 0
+
+    for id in eachindex(keys)
+        key = keys[id]
+
+        if !(key isa Vector{Any})
+            name[id] = key[2]                       # a leaf: use it directly
+        else
+            expr = Expr(:call, key[1], (name[arg] for arg in @view key[2:end])...)
+
+            if counts[id] > 1
+                # Used more than once, so it earns a name. Its arguments already have theirs.
+                n += 1
+                sym = Symbol(prefix, n)
+                push!(stmts, Expr(:(=), sym, expr))
+                name[id] = sym
+            else
+                # Used once: splice it in where it is used rather than spending a local on it.
+                name[id] = expr
+            end
+        end
+    end
+
+    push!(stmts, name[root])
+
+    Expr(:block, stmts...)
+end
+
+
 fnesc(name, escape) = escape ? esc(name) : name
 
 
 """
-Generate code for evaluating analytic equilibria.
+    code(equ, pert = ZeroPerturbation(); export_parameters = true, escape = false, output = 0, cse = true)
+
+Generate code for evaluating analytic equilibria: an `Expr` defining the field functions of `equ`,
+which `@code` splices into the calling module and [`load_equilibrium`](@ref) evaluates into one.
+
+* `export_parameters` also emits the equilibrium's scalar parameters as constants.
+* `escape` escapes the generated names, which a macro splicing this into another module needs.
+* `output` is 0, 1 or 2: silent, one line per function, or the generated body as well.
+* `cse` names each repeated subexpression once instead of emitting it in full every time it occurs.
+  This is on by default and is value-preserving to the last bit — subexpressions are named, never
+  rewritten — but the generated code is easier to read against a paper with it off. It matters:
+  SymEngine shares nothing, so `db₁dx₁` of the ITER Solov'ev equilibrium with an X-point contains
+  108 separate evaluations of `log(x₁)` without it, and is 6.8 times slower.
 """
-function code(equ, pert=ZeroPerturbation(); export_parameters=true, escape=false, output=0)
+function code(equ, pert=ZeroPerturbation(); export_parameters=true, escape=false, output=0, cse=true)
 
     if output ≥ 1
         println("Generating code for ")
@@ -618,6 +730,14 @@ function code(equ, pert=ZeroPerturbation(); export_parameters=true, escape=false
 
         f_body = convert(Expr, f_expr)
         replace_expr!(f_body, :atan2, :atan)
+
+        # Only the bodies that came out of SymEngine. The rest of `functions` holds hand-written
+        # `quote` blocks — the `a`/`b`/`c` triads, `g`, `ḡ`, `DF`, `to_cartesian`, `rangemin` — whose
+        # heads are not `:call` and which have nothing to share anyway.
+        if cse && f_expr isa Basic && f_body isa Expr
+            f_body = eliminate_common_subexpressions(f_body)
+        end
+
         output ≥ 2 ? println("   ", f_body) : nothing
 
         f_code = quote
@@ -654,8 +774,8 @@ end
 """
 Evaluate functions for evaluating analytic equilibria.
 """
-function load_equilibrium(equ, pert=ZeroPerturbation(); target_module=Main, output=0)
-    equ_code = code(equ, pert; output=output)
+function load_equilibrium(equ, pert=ZeroPerturbation(); target_module=Main, output=0, cse=true)
+    equ_code = code(equ, pert; output=output, cse=cse)
     Core.eval(target_module, equ_code)
 end
 

--- a/src/analytic/axisymmetric_tokamak_cartesian.jl
+++ b/src/analytic/axisymmetric_tokamak_cartesian.jl
@@ -20,7 +20,7 @@ module AxisymmetricTokamakCartesian
     using RecipesBase
 
     import ..ElectromagneticFields
-    import ..ElectromagneticFields: CartesianEquilibrium, code
+    import ..ElectromagneticFields: CartesianEquilibrium, code, code_arguments
     import ..AnalyticCartesianField: X, Y, Z
 
     export  AxisymmetricTokamakCartesianEquilibrium
@@ -54,12 +54,14 @@ module AxisymmetricTokamakCartesian
         AxisymmetricTokamakCartesianEquilibrium(ITER_R₀, ITER_B₀, ITER_q₀)
     end
 
-    macro code(R₀=DEFAULT_R₀, B₀=DEFAULT_B₀, q₀=DEFAULT_q₀)
-        code(init(R₀, B₀, q₀); escape=true)
+    macro code(args...)
+        parameters, options = code_arguments(args)
+        code(init(parameters...); escape=true, options...)
     end
 
-    macro code_iter()
-        code(ITER(); escape=true)
+    macro code_iter(args...)
+        parameters, options = code_arguments(args)
+        code(ITER(parameters...); escape=true, options...)
     end
 
     function Base.show(io::IO, equ::AxisymmetricTokamakCartesianEquilibrium)

--- a/src/analytic/axisymmetric_tokamak_cylindrical.jl
+++ b/src/analytic/axisymmetric_tokamak_cylindrical.jl
@@ -22,7 +22,7 @@ using RecipesBase
 import NaNMath: log
 
 import ..ElectromagneticFields
-import ..ElectromagneticFields: AnalyticEquilibrium, code
+import ..ElectromagneticFields: AnalyticEquilibrium, code, code_arguments
 
 export AxisymmetricTokamakCylindricalEquilibrium
 
@@ -55,12 +55,14 @@ function ITER()
     AxisymmetricTokamakCylindricalEquilibrium(ITER_R₀, ITER_B₀, ITER_q₀)
 end
 
-macro code(R₀=DEFAULT_R₀, B₀=DEFAULT_B₀, q₀=DEFAULT_q₀)
-    code(init(R₀, B₀, q₀); escape=true)
+macro code(args...)
+    parameters, options = code_arguments(args)
+    code(init(parameters...); escape=true, options...)
 end
 
-macro code_iter()
-    code(ITER(); escape=true)
+macro code_iter(args...)
+    parameters, options = code_arguments(args)
+    code(ITER(parameters...); escape=true, options...)
 end
 
 function Base.show(io::IO, equ::AxisymmetricTokamakCylindricalEquilibrium)

--- a/src/analytic/axisymmetric_tokamak_toroidal.jl
+++ b/src/analytic/axisymmetric_tokamak_toroidal.jl
@@ -30,6 +30,10 @@ const DEFAULT_R₀ = 1.0
 const DEFAULT_B₀ = 1.0
 const DEFAULT_q₀ = 2.0
 
+const ITER_R₀ = 6.2
+const ITER_B₀ = 5.3
+const ITER_q₀ = √2
+
 struct AxisymmetricTokamakToroidalEquilibrium{T<:Number} <: AnalyticEquilibrium
     name::String
     R₀::T

--- a/src/analytic/axisymmetric_tokamak_toroidal.jl
+++ b/src/analytic/axisymmetric_tokamak_toroidal.jl
@@ -22,7 +22,7 @@ using RecipesBase
 import NaNMath: log
 
 import ..ElectromagneticFields
-import ..ElectromagneticFields: AnalyticEquilibrium, code
+import ..ElectromagneticFields: AnalyticEquilibrium, code, code_arguments
 
 export AxisymmetricTokamakToroidalEquilibrium
 
@@ -51,12 +51,14 @@ function ITER()
     AxisymmetricTokamakToroidalEquilibrium(ITER_R₀, ITER_B₀, ITER_q₀)
 end
 
-macro code(R₀=DEFAULT_R₀, B₀=DEFAULT_B₀, q₀=DEFAULT_q₀)
-    code(init(R₀, B₀, q₀); escape=true)
+macro code(args...)
+    parameters, options = code_arguments(args)
+    code(init(parameters...); escape=true, options...)
 end
 
-macro code_iter()
-    code(ITER(); escape=true)
+macro code_iter(args...)
+    parameters, options = code_arguments(args)
+    code(ITER(parameters...); escape=true, options...)
 end
 
 function Base.show(io::IO, equ::AxisymmetricTokamakToroidalEquilibrium)

--- a/src/analytic/axisymmetric_tokamak_toroidal_regularization.jl
+++ b/src/analytic/axisymmetric_tokamak_toroidal_regularization.jl
@@ -20,7 +20,7 @@ module AxisymmetricTokamakToroidalRegularization
 import NaNMath: log
 
 import ..ElectromagneticFields
-import ..ElectromagneticFields: AnalyticEquilibrium, code
+import ..ElectromagneticFields: AnalyticEquilibrium, code, code_arguments
 
 export AxisymmetricTokamakToroidalRegularizationEquilibrium
 
@@ -45,8 +45,9 @@ function init(R₀=DEFAULT_R₀, B₀=DEFAULT_B₀, q₀=DEFAULT_q₀)
     AxisymmetricTokamakToroidalRegularizationEquilibrium(R₀, B₀, q₀)
 end
 
-macro code(R₀=DEFAULT_R₀, B₀=DEFAULT_B₀, q₀=DEFAULT_q₀)
-    code(init(R₀, B₀, q₀); escape=true)
+macro code(args...)
+    parameters, options = code_arguments(args)
+    code(init(parameters...); escape=true, options...)
 end
 
 function Base.show(io::IO, equ::AxisymmetricTokamakToroidalRegularizationEquilibrium)

--- a/src/analytic/dipole.jl
+++ b/src/analytic/dipole.jl
@@ -18,7 +18,7 @@ using RecipesBase
 using LaTeXStrings
 
 import ..ElectromagneticFields
-import ..ElectromagneticFields: CartesianEquilibrium, code
+import ..ElectromagneticFields: CartesianEquilibrium, code, code_arguments
 import ..AnalyticCartesianField: X, Y, Z
 
 export DipoleField
@@ -41,7 +41,8 @@ function init(args...)
 end
 
 macro code(args...)
-    code(init(args...); escape=true)
+    parameters, options = code_arguments(args)
+    code(init(parameters...); escape=true, options...)
 end
 
 function Base.show(io::IO, equ::DipoleField)

--- a/src/analytic/ezcosz.jl
+++ b/src/analytic/ezcosz.jl
@@ -13,7 +13,7 @@ Parameters: `E₀`
 module EzCosZ
 
     import ..ElectromagneticFields
-    import ..ElectromagneticFields: CartesianPerturbation, code
+    import ..ElectromagneticFields: CartesianPerturbation, code, code_arguments
     import ..AnalyticCartesianField: X, Y, Z
 
     export EzCosZPerturbation
@@ -32,8 +32,9 @@ module EzCosZ
         EzCosZPerturbation(E₀)
     end
 
-    macro code(E₀=DEFAULT_E₀)
-        code(init(E₀); escape=true)
+    macro code(args...)
+        parameters, options = code_arguments(args)
+        code(init(parameters...); escape=true, options...)
     end
 
     function Base.show(io::IO, equ::EzCosZPerturbation)

--- a/src/analytic/penning_trap_asymmetric.jl
+++ b/src/analytic/penning_trap_asymmetric.jl
@@ -30,7 +30,7 @@ module PenningTrapAsymmetric
     using RecipesBase
 
     import ..ElectromagneticFields
-    import ..ElectromagneticFields: CartesianEquilibrium, code
+    import ..ElectromagneticFields: CartesianEquilibrium, code, code_arguments
     import ..AnalyticCartesianField: X, Y, Z
 
     export  PenningTrapAsymmetricEquilibrium
@@ -56,8 +56,9 @@ module PenningTrapAsymmetric
         PenningTrapAsymmetricEquilibrium(B₀, E₀, Bₚ)
     end
 
-    macro code(B₀=DEFAULT_B₀, Bₚ=DEFAULT_Bₚ, E₀=DEFAULT_E₀)
-        code(init(B₀, Bₚ, E₀); escape=true)
+    macro code(args...)
+        parameters, options = code_arguments(args)
+        code(init(parameters...); escape=true, options...)
     end
 
     function Base.show(io::IO, equ::PenningTrapAsymmetricEquilibrium)

--- a/src/analytic/penning_trap_asymmetric.jl
+++ b/src/analytic/penning_trap_asymmetric.jl
@@ -53,7 +53,7 @@ module PenningTrapAsymmetric
     PenningTrapAsymmetricEquilibrium(B₀::T=DEFAULT_B₀, Bₚ::T=DEFAULT_Bₚ, E₀::T=DEFAULT_E₀) where T <: Number = PenningTrapAsymmetricEquilibrium{T}(B₀, Bₚ, E₀)
 
     function init(B₀=DEFAULT_B₀, Bₚ=DEFAULT_Bₚ, E₀=DEFAULT_E₀)
-        PenningTrapAsymmetricEquilibrium(B₀, E₀, Bₚ)
+        PenningTrapAsymmetricEquilibrium(B₀, Bₚ, E₀)
     end
 
     macro code(args...)

--- a/src/analytic/penning_trap_bottle.jl
+++ b/src/analytic/penning_trap_bottle.jl
@@ -30,7 +30,7 @@ module PenningTrapBottle
     using RecipesBase
 
     import ..ElectromagneticFields
-    import ..ElectromagneticFields: CartesianEquilibrium, code
+    import ..ElectromagneticFields: CartesianEquilibrium, code, code_arguments
     import ..AnalyticCartesianField: X, Y, Z
 
     export  PenningTrapBottleEquilibrium
@@ -56,8 +56,9 @@ module PenningTrapBottle
         PenningTrapBottleEquilibrium(B₀, E₀, Bₚ)
     end
 
-    macro code(B₀=DEFAULT_B₀, Bₚ=DEFAULT_Bₚ, E₀=DEFAULT_E₀)
-        code(init(B₀, Bₚ, E₀); escape=true)
+    macro code(args...)
+        parameters, options = code_arguments(args)
+        code(init(parameters...); escape=true, options...)
     end
 
     function Base.show(io::IO, equ::PenningTrapBottleEquilibrium)

--- a/src/analytic/penning_trap_bottle.jl
+++ b/src/analytic/penning_trap_bottle.jl
@@ -53,7 +53,7 @@ module PenningTrapBottle
     PenningTrapBottleEquilibrium(B₀::T=DEFAULT_B₀, Bₚ::T=DEFAULT_Bₚ, E₀::T=DEFAULT_E₀) where T <: Number = PenningTrapBottleEquilibrium{T}(B₀, Bₚ, E₀)
 
     function init(B₀=DEFAULT_B₀, Bₚ=DEFAULT_Bₚ, E₀=DEFAULT_E₀)
-        PenningTrapBottleEquilibrium(B₀, E₀, Bₚ)
+        PenningTrapBottleEquilibrium(B₀, Bₚ, E₀)
     end
 
     macro code(args...)

--- a/src/analytic/penning_trap_uniform.jl
+++ b/src/analytic/penning_trap_uniform.jl
@@ -29,7 +29,7 @@ module PenningTrapUniform
     using RecipesBase
 
     import ..ElectromagneticFields
-    import ..ElectromagneticFields: CartesianEquilibrium, code
+    import ..ElectromagneticFields: CartesianEquilibrium, code, code_arguments
     import ..AnalyticCartesianField: X, Y, Z
 
     export  PenningTrapUniformEquilibrium
@@ -53,8 +53,9 @@ module PenningTrapUniform
         PenningTrapUniformEquilibrium(B₀, E₀)
     end
     
-    macro code(B₀=DEFAULT_B₀, E₀=DEFAULT_E₀)
-        code(init(B₀, E₀); escape=true)
+    macro code(args...)
+        parameters, options = code_arguments(args)
+        code(init(parameters...); escape=true, options...)
     end
 
     function Base.show(io::IO, equ::PenningTrapUniformEquilibrium)

--- a/src/analytic/quadratic_potentials.jl
+++ b/src/analytic/quadratic_potentials.jl
@@ -22,7 +22,7 @@ using RecipesBase
 using LaTeXStrings
 
 import ..ElectromagneticFields
-import ..ElectromagneticFields: CartesianEquilibrium, code
+import ..ElectromagneticFields: CartesianEquilibrium, code, code_arguments
 import ..AnalyticCartesianField: X, Y, Z
 
 export QuadraticPotentialsField
@@ -45,7 +45,8 @@ function init(args...)
 end
 
 macro code(args...)
-    code(init(args...); escape=true)
+    parameters, options = code_arguments(args)
+    code(init(parameters...); escape=true, options...)
 end
 
 function Base.show(io::IO, equ::QuadraticPotentialsField)

--- a/src/analytic/singular.jl
+++ b/src/analytic/singular.jl
@@ -22,7 +22,7 @@ module Singular
     using RecipesBase
 
     import ..ElectromagneticFields
-    import ..ElectromagneticFields: CartesianEquilibrium, code
+    import ..ElectromagneticFields: CartesianEquilibrium, code, code_arguments
     import ..ElectromagneticFields: A₁, A₂, A₃
     import ..AnalyticCartesianField: X, Y, Z
 
@@ -42,8 +42,9 @@ module Singular
         SingularEquilibrium(B₀)
     end
 
-    macro code(B₀=DEFAULT_B₀)
-        code(init(B₀); escape=true)
+    macro code(args...)
+        parameters, options = code_arguments(args)
+        code(init(parameters...); escape=true, options...)
     end
 
 

--- a/src/analytic/solovev.jl
+++ b/src/analytic/solovev.jl
@@ -12,7 +12,7 @@ using SymEngine: N, symbols, diff, expand, subs
 import NaNMath: log
 
 import ..ElectromagneticFields
-import ..ElectromagneticFields: code
+import ..ElectromagneticFields: code, code_arguments
 import ..SolovevAbstract: AbstractSolovevEquilibrium, X, Y, Z, R, r, θ, ϕ, r²
 
 export SolovevEquilibrium, SolovevXpointEquilibrium
@@ -199,8 +199,9 @@ function init(R₀, B₀, ϵ, κ, δ, α)
     SolovevEquilibrium(R₀, B₀, ϵ, κ, δ, α)
 end
 
-macro code(R₀, B₀, ϵ, κ, δ, α)
-    code(init(R₀, B₀, ϵ, κ, δ, α); escape=true)
+macro code(args...)
+    parameters, options = code_arguments(args)
+    code(init(parameters...); escape=true, options...)
 end
 
 
@@ -414,8 +415,9 @@ function init(R₀, B₀, ϵ, κ, δ, α, xsep, ysep, doublex=false)
     end
 end
 
-macro code_xpoint(R₀, B₀, ϵ, κ, δ, α, xsep, ysep, doublex=false)
-    code(SolovevXpointEquilibrium(R₀, B₀, ϵ, κ, δ, α, xsep, ysep, doublex); escape=true)
+macro code_xpoint(args...)
+    parameters, options = code_arguments(args)
+    code(init(parameters...); escape=true, options...)
 end
 
 
@@ -478,33 +480,39 @@ function FRC()
 end
 
 
-macro code_iter(xpoint=false)
-    code(ITER(xpoint=xpoint); escape=true)
+macro code_iter(args...)
+    parameters, options = code_arguments(args)
+    code(ITER(xpoint=get(parameters, 1, false)); escape=true, options...)
 end
 
-macro code_iter_xpoint()
-    code(ITER(xpoint=true); escape=true)
+macro code_iter_xpoint(args...)
+    _, options = code_arguments(args)
+    code(ITER(xpoint=true); escape=true, options...)
 end
 
-macro code_nstx(xpoint=false)
-    code(NSTX(xpoint=xpoint); escape=true)
+macro code_nstx(args...)
+    parameters, options = code_arguments(args)
+    code(NSTX(xpoint=get(parameters, 1, false)); escape=true, options...)
 end
 
-macro code_nstx_xpoint(doublex=false)
-    if doublex
+macro code_nstx_xpoint(args...)
+    parameters, options = code_arguments(args)
+    if get(parameters, 1, false)
         equilibrium = NSTXdoubleX()
     else
         equilibrium = NSTX(xpoint=true)
     end
-    code(equilibrium; escape=true)
+    code(equilibrium; escape=true, options...)
 end
 
-macro code_nstx_double_xpoint()
-    code(NSTXdoubleX(); escape=true)
+macro code_nstx_double_xpoint(args...)
+    _, options = code_arguments(args)
+    code(NSTXdoubleX(); escape=true, options...)
 end
 
-macro code_frc()
-    code(FRC(); escape=true)
+macro code_frc(args...)
+    _, options = code_arguments(args)
+    code(FRC(); escape=true, options...)
 end
 
 

--- a/src/analytic/solovev.jl
+++ b/src/analytic/solovev.jl
@@ -210,8 +210,16 @@ SolovevEquilibriumITER() = SolovevEquilibrium(6.2, 5.3, 0.32, 1.7, 0.33, -0.155)
 # SolovevEquilibriumJET()  = SolovevEquilibrium(3.0, 3.6, 0.333, 1.7, 0.25, )
 SolovevEquilibriumNSTX() = SolovevEquilibrium(0.85, 0.30, 0.78, 2.00, 0.35, 1.0)
 # SolovevEquilibriumMAST() = SolovevEquilibrium(0.85, 0.52, 0.77, 2.45, 0.50,  )
-SolovevEquilibriumFRC() = SolovevEquilibrium(0.0, 0.0, 0.99, 10.0, 0.7, 0.0)
-# SolovevEquilibriumFRC2() = SolovevEquilibrium(0.0, 0.0, 1.00, 10., 1.0, 0.0)
+# Cerfon & Freidberg, Sec. VIII: an FRC "is very elongated (i.e. κ ~ 10) and has zero toroidal field
+# (i.e. B₀ = 0) implying that A = 0", approximated by their first method with ϵ = 0.99 and δ = 0.7.
+# `B₀ = 0` is the physics — the toroidal field is absent and A₃ = ψ carries the poloidal field alone.
+# `R₀` is the major radius the paper normalises with (R = R₀x, Z = R₀y), so it cannot be zero: it
+# enters the metric as g₁₁ = g₂₂ = R₀². One is the natural choice in these normalised coordinates.
+SolovevEquilibriumFRC() = SolovevEquilibrium(1.0, 0.0, 0.99, 10.0, 0.7, 0.0)
+# Their second method, ϵ = 1 and δ = 1, needs the half-ellipse constraints of their Eqs. (23)–(25)
+# rather than the seven above — with ϵ = 1 the inner equatorial point falls on x₁ = 0 and log(x₁)
+# diverges — so it stays out until those are implemented.
+# SolovevEquilibriumFRC2() = SolovevEquilibrium(1.0, 0.0, 1.00, 10., 1.0, 0.0)
 
 
 function Base.show(io::IO, equ::SolovevEquilibrium)

--- a/src/analytic/solovev_symmetric.jl
+++ b/src/analytic/solovev_symmetric.jl
@@ -17,7 +17,7 @@ module SolovevSymmetric
     using RecipesBase
 
     import ..ElectromagneticFields
-    import ..ElectromagneticFields: CartesianEquilibrium, code
+    import ..ElectromagneticFields: CartesianEquilibrium, code, code_arguments
     import ..AnalyticCartesianField: X, Y, Z
 
     export  SolovevSymmetricEquilibrium
@@ -47,8 +47,9 @@ module SolovevSymmetric
         SolovevSymmetricEquilibrium(R₀, B₀, α, β)
     end
 
-    macro code(R₀=DEFAULT_R₀, B₀=DEFAULT_B₀, α=DEFAULT_α, β=DEFAULT_β)
-        code(init(R₀, B₀, α, β); escape=true)
+    macro code(args...)
+        parameters, options = code_arguments(args)
+        code(init(parameters...); escape=true, options...)
     end
 
     function Base.show(io::IO, equ::SolovevSymmetricEquilibrium)

--- a/src/analytic/symmetric_quadratic.jl
+++ b/src/analytic/symmetric_quadratic.jl
@@ -21,7 +21,7 @@ module SymmetricQuadratic
     using LaTeXStrings
 
     import ..ElectromagneticFields
-    import ..ElectromagneticFields: CartesianEquilibrium, code
+    import ..ElectromagneticFields: CartesianEquilibrium, code, code_arguments
     import ..ElectromagneticFields: A₁, A₂, A₃
     import ..AnalyticCartesianField: X, Y, Z
 
@@ -41,8 +41,9 @@ module SymmetricQuadratic
         SymmetricQuadraticEquilibrium(B₀)
     end
 
-    macro code(B₀=DEFAULT_B₀)
-        code(init(B₀); escape=true)
+    macro code(args...)
+        parameters, options = code_arguments(args)
+        code(init(parameters...); escape=true, options...)
     end
 
 

--- a/src/analytic/theta_pinch.jl
+++ b/src/analytic/theta_pinch.jl
@@ -18,7 +18,7 @@ module ThetaPinch
     using LaTeXStrings
 
     import ..ElectromagneticFields
-    import ..ElectromagneticFields: CartesianEquilibrium, code
+    import ..ElectromagneticFields: CartesianEquilibrium, code, code_arguments
     import ..AnalyticCartesianField: X, Y, Z
 
     export ThetaPinchEquilibrium
@@ -41,8 +41,9 @@ module ThetaPinch
         ThetaPinchEquilibrium(B₀)
     end
 
-    macro code(B₀=DEFAULT_B₀)
-        code(init(B₀); escape=true)
+    macro code(args...)
+        parameters, options = code_arguments(args)
+        code(init(parameters...); escape=true, options...)
     end
 
 

--- a/test/test_analytic.jl
+++ b/test/test_analytic.jl
@@ -598,4 +598,97 @@ end
     test_consistency_axisymmetric_tokamak_toroidal_equilibrium(AxisymmetricTokamakToroidalTest, AxisymmetricTokamakCartesianTest)
 end
 
+
+# `code` runs every SymEngine-derived body through `eliminate_common_subexpressions`, which is only
+# safe because it names subexpressions rather than rewriting them. That claim is what is checked
+# here — that the eliminated block still denotes the very same expression — for every generated
+# function of every equilibrium.
+#
+# Structurally rather than numerically, because the numeric alternative does not scale. Comparing
+# values means compiling both versions of all ~440 functions per equilibrium, and `d²b₁dx₁dx₁` alone
+# is 6231 statements before elimination; a numeric sweep over the Solov'ev equilibria does not
+# finish. The structural identity is also the stronger statement — it holds at every point at once,
+# rather than at whichever sample points the test happened to choose.
+#
+# The comparison never materialises the expansion. Both expressions are interned into one table keyed
+# by structure — a call by its head and the ids of its arguments, a leaf by its type and value — with
+# each temporary resolving to the id its right-hand side was given. Two expressions land on the same
+# id exactly when they are structurally identical, so the block denotes the body iff its last
+# statement interns to the body's root id, and that is linear in the size of the expression.
+#
+# Substituting the temporaries back and comparing trees is the obvious alternative, and is quadratic:
+# each definition would hold the full expansion of its own subtree, so the work is the sum of all of
+# them. It does not finish on the Solov'ev second derivatives.
+function same_expression(body::Expr, block::Expr)
+    ids = Dict{Any,Int}()
+    next_id = Ref(0)
+
+    intern(key) = get!(() -> (next_id[] += 1), ids, key)
+
+    visit(e, env) =
+        e isa Symbol && haskey(env, e) ? env[e] :
+        e isa Expr && e.head === :call ?
+        intern(Any[e.args[1]; Int[visit(a, env) for a in @view e.args[2:end]]]) :
+        intern((typeof(e), e))
+
+    root = visit(body, Dict{Symbol,Int}())
+
+    environment = Dict{Symbol,Int}()
+    value = 0
+
+    for statement in block.args
+        if statement isa Expr && statement.head === :(=)
+            environment[statement.args[1]] = visit(statement.args[2], environment)
+        else
+            value = visit(statement, environment)
+        end
+    end
+
+    value == root
+end
+
+# The same equilibria `@test_equilibrium` covers above, and for the same reason in the one case it
+# skips: `SolovevFRC` is `SolovevEquilibrium(0.0, 0.0, 0.99, 10.0, 0.7, 0.0)`, and with `R₀ = 0` the
+# flux function degenerates and `generate_equilibrium_functions` does not return.
+const cse_equilibria = (
+    ("ABC", ElectromagneticFields.ABC.init()),
+    ("AxisymmetricTokamakCartesian", ElectromagneticFields.AxisymmetricTokamakCartesian.init()),
+    ("AxisymmetricTokamakCylindrical", ElectromagneticFields.AxisymmetricTokamakCylindrical.init()),
+    ("AxisymmetricTokamakToroidal", ElectromagneticFields.AxisymmetricTokamakToroidal.init()),
+    ("AxisymmetricTokamakToroidalRegularization", ElectromagneticFields.AxisymmetricTokamakToroidalRegularization.init()),
+    ("Dipole", ElectromagneticFields.Dipole.init()),
+    ("PenningTrapUniform", ElectromagneticFields.PenningTrapUniform.init()),
+    ("PenningTrapBottle", ElectromagneticFields.PenningTrapBottle.init()),
+    ("PenningTrapAsymmetric", ElectromagneticFields.PenningTrapAsymmetric.init()),
+    ("QuadraticPotentials", ElectromagneticFields.QuadraticPotentials.init()),
+    ("Singular", ElectromagneticFields.Singular.init()),
+    ("SolovevITER", ElectromagneticFields.Solovev.ITER()),
+    ("SolovevITERwXpoint", ElectromagneticFields.Solovev.ITER(xpoint=true)),
+    ("SolovevNSTX", ElectromagneticFields.Solovev.NSTX()),
+    ("SolovevNSTXwXpoint", ElectromagneticFields.Solovev.NSTX(xpoint=true)),
+    ("SolovevNSTXwDoubleXpoint", ElectromagneticFields.Solovev.NSTXdoubleX()),
+    ("SolovevSymmetric", ElectromagneticFields.SolovevSymmetric.init()),
+    ("SymmetricQuadratic", ElectromagneticFields.SymmetricQuadratic.init()),
+    ("ThetaPinch", ElectromagneticFields.ThetaPinch.init()),
+)
+
+@testset "$(rpad("Common subexpression elimination preserves every value",60))" begin
+    for (name, equ) in cse_equilibria
+        @testset "$(rpad(name,56))" begin
+            functions = ElectromagneticFields.generate_equilibrium_functions(equ, ZeroPerturbation())
+
+            for (key, expression) in functions
+                expression isa ElectromagneticFields.SymEngine.Basic || continue
+
+                body = convert(Expr, expression)
+                ElectromagneticFields.replace_expr!(body, :atan2, :atan)
+                body isa Expr || continue
+
+                @test same_expression(body,
+                    ElectromagneticFields.eliminate_common_subexpressions(body))
+            end
+        end
+    end
+end
+
 println()

--- a/test/test_analytic.jl
+++ b/test/test_analytic.jl
@@ -447,7 +447,7 @@ perts = (
 @test_equilibrium Singular [-Inf, -Inf, -Inf] [+Inf, +Inf, +Inf]
 @test_equilibrium SymmetricQuadratic [-Inf, -Inf, -Inf] [+Inf, +Inf, +Inf]
 @test_equilibrium ThetaPinch [-Inf, -Inf, -Inf] [+Inf, +Inf, +Inf]
-# @test_equilibrium SolovevFRC                                    [0., 0., 2π]
+@test_equilibrium SolovevFRC [-Inf, -Inf, 0.0] [+Inf, +Inf, 2π]
 @test_equilibrium SolovevITER [-Inf, -Inf, 0.0] [+Inf, +Inf, 2π]
 @test_equilibrium SolovevITERwXpoint [-Inf, -Inf, 0.0] [+Inf, +Inf, 2π]
 @test_equilibrium SolovevNSTX [-Inf, -Inf, 0.0] [+Inf, +Inf, 2π]
@@ -647,9 +647,7 @@ function same_expression(body::Expr, block::Expr)
     value == root
 end
 
-# The same equilibria `@test_equilibrium` covers above, and for the same reason in the one case it
-# skips: `SolovevFRC` is `SolovevEquilibrium(0.0, 0.0, 0.99, 10.0, 0.7, 0.0)`, and with `R₀ = 0` the
-# flux function degenerates and `generate_equilibrium_functions` does not return.
+# The same equilibria `@test_equilibrium` covers above.
 const cse_equilibria = (
     ("ABC", ElectromagneticFields.ABC.init()),
     ("AxisymmetricTokamakCartesian", ElectromagneticFields.AxisymmetricTokamakCartesian.init()),
@@ -662,6 +660,7 @@ const cse_equilibria = (
     ("PenningTrapAsymmetric", ElectromagneticFields.PenningTrapAsymmetric.init()),
     ("QuadraticPotentials", ElectromagneticFields.QuadraticPotentials.init()),
     ("Singular", ElectromagneticFields.Singular.init()),
+    ("SolovevFRC", ElectromagneticFields.Solovev.FRC()),
     ("SolovevITER", ElectromagneticFields.Solovev.ITER()),
     ("SolovevITERwXpoint", ElectromagneticFields.Solovev.ITER(xpoint=true)),
     ("SolovevNSTX", ElectromagneticFields.Solovev.NSTX()),


### PR DESCRIPTION
`convert(Expr, ::Basic)` writes out SymEngine's expanded tree verbatim, and SymEngine shares
nothing. A subexpression common to fifty branches of `∂ⱼ(Bᵢ / sqrt(gᵏˡBₖBₗ))` is emitted fifty
times, and the Solov'ev flux functions carry `x² log x` terms, so on the ITER equilibrium with an
X-point:

| generated function | nodes in the expression | `log` calls | `^` calls |
|---|---|---|---|
| `B` | 350 | 15 | 42 |
| `b₁` | 514 | 21 | 63 |
| `dBdx₁` | 1281 | 60 | 145 |
| `db₁dx₁` | 2415 | **108** | **280** |
| `d²b₁dx₁dx₁` | 7935 | 367 | 904 |

Every one of those 108 logs is `log(ξ₁)`.

This adds a pass between `convert(Expr, f_expr)` and the `quote` that wraps the body, so each
distinct subexpression is evaluated once into a local and read back afterwards. The five bodies above
come out as 10, 29, 51, 70 and 108 statements.

## It only names subexpressions

The pass never reassociates, never reorders an operand, never folds a constant. Generated functions
return bit-for-bit what they returned before.

`test/test_analytic.jl` asserts this structurally for **every generated function of every
equilibrium it covers** — 8824 assertions, 1.0 s. Both expressions are interned into one table keyed
by structure (a call by its head and the ids of its arguments, a leaf by its type and value), with
each temporary resolving to the id its right-hand side was given; the block is equivalent iff its
last statement lands on the body's root id.

Keying leaves by type as well as value is load-bearing rather than defensive: the bodies contain
`Int64`, `Float64` and `Rational{Int64}` literals, and `isequal(2, 2.0)`, `isequal(2, 2//1)` and
`isequal(2.0, 2//1)` are all true, so without the type `x^2` could be emitted as `x^2.0`.

Structural rather than numerical, deliberately. Comparing values means compiling both versions of
all ~440 functions per equilibrium, and at 7935 nodes for `d²b₁dx₁dx₁` that does not finish. The
structural identity is also the stronger statement: it holds at every point at once, rather than
at whichever samples a test picks.

The check has teeth — it rejects an operand swap, a `^` changed to `*`, a temporary aliased to
another temporary, a literal moved by one ulp, an integer exponent bumped by one, an `n`-ary `+`
with its summands rotated, a statement pair reordered so a temporary is read before it is written,
and the whole result scaled. It accepts a reorder of two *independent* statements, which is
value-preserving.

## Effect

Measured on `Solovev.ITER(xpoint = true)`:

| function | `log` emitted | before | after | speedup |
|---|---|---|---|---|
| `B` | 15 → 1 | 98 ns | 41 ns | 2.4× |
| `b₁` | 21 → 1 | 130 ns | 40 ns | 3.3× |
| `dBdx₁` | 60 → 1 | 294 ns | 47 ns | 6.3× |
| `db₁dx₁` | 108 → 1 | 566 ns | 83 ns | 6.8× |
| `d²b₁dx₁dx₁` | 367 → 1 | 1749 ns | 137 ns | 12.8× |

First-call latency falls with it, because the code being compiled is smaller — `d²b₁dx₁dx₁`
compiles in 12 ms rather than 118 ms, and `load_equilibrium(Solovev.ITER(xpoint = true))` end to end
goes from 1.07 s to 0.80 s.

The emitted code gets **smaller**, not larger — sharing more than pays for the assignments. Emitted
characters, counting the generated code itself (`Base.remove_linenums!` applied, since the
`LineNumberNode`s are the same either way):

| equilibrium | `log` calls emitted | emitted characters |
|---|---|---|
| ITER Solov'ev with X-point | 7053 → 83 | 721,382 → 352,669 |
| Axisymmetric tokamak, toroidal | 697 → 65 | 313,523 → 192,339 |
| Axisymmetric tokamak, cartesian | 2 → 2 | 740,021 → 346,529 |

Across nineteen of the equilibria the suite covers, the pass costs **0.99 s** against the **18.9 s**
SymEngine already spends differentiating them, and the equivalence check a further 0.57 s.

## Implementation

Hash-consing rather than hashing whole `Expr`s: a node is keyed by its head and the integer ids of
its arguments, so no subtree is ever hashed or printed as a whole and the pass is linear in the size
of the expression. The obvious version — `Dict{Expr,Int}` keyed by the subtrees themselves, sorted by
printed length to get a topological order — is quadratic and does not finish on the Solov'ev second
derivatives. Ids are handed out in post-order, so a node's arguments always have smaller ids and
emitting temporaries in increasing id order is topological by construction.

Only SymEngine-derived bodies are touched; the hand-written `quote` blocks in `code` (the `a`/`b`/`c`
triads, `g`, `ḡ`, `DF`, `to_cartesian`, `rangemin`) pass through unchanged. Those are the only ones
that could need it: across all twenty equilibria, every one of the 8824 SymEngine bodies is a pure
`:call` tree, with no other `Expr` head anywhere in it.

`cse = false` turns it off — useful for reading generated code against a paper, and an escape hatch
if a downstream equilibrium ever misbehaves. Macros cannot take keyword arguments, so the `@code`
macros take it as a `key = value` argument the way `@testset` does:

```julia
ThetaPinch.@code cse = false            # defaults for the equilibrium's parameters
ThetaPinch.@code(B₀, cse = false)       # or alongside them
code(equ; cse = false)                  # and directly, as before
load_equilibrium(equ; cse = false)
```

`code_arguments` splits a macro's arguments into the equilibrium's parameters and the options, so
`output` comes along for free too. The positional defaults move from the macro signatures to `init`,
which already carried the same ones. Two side effects of routing `@code_xpoint` through `init` like
every other macro: it stops calling a nine-argument `SolovevXpointEquilibrium` that has no such
method, and it honours `doublex` — both of which `init` already handled.

The new testset covers the same equilibria as `@test_equilibrium` — all twenty, none skipped.

## Why

`ChargedParticleDynamics` splices these functions into 13 guiding-centre and 8 Pauli equilibrium
modules, and its 3D guiding centre right-hand side is dominated by `dbᵢdxⱼ`. This is the last of
three costs in that model; the other two — an initial-guess extrapolator that was 70 % of wall clock,
and a right-hand side that re-entered the generated code seventy times per evaluation — were fixed on
its side, together worth about 20×.

## Pre-existing bugs fixed along the way

Three bugs surfaced while exercising the `@code` macro call forms above. None is caused by the CSE
pass, and none is new to this branch — they are fixed here because this is where they were found, in
one commit each.

* **`AxisymmetricTokamakToroidal.ITER()` raised `UndefVarError`.** It referenced `ITER_R₀`, `ITER_B₀`
  and `ITER_q₀`, which only the cylindrical and cartesian modules ever defined. `@code_iter` was
  unusable in that module. Added, byte-identical to the cylindrical module's.

* **`PenningTrapBottle.init` and `PenningTrapAsymmetric.init` swapped `Bₚ` and `E₀`.** Both take
  `(B₀, Bₚ, E₀)` and constructed `…Equilibrium(B₀, E₀, Bₚ)`. **This changes the default equilibria,
  not only explicit calls:** Bottle moves from `Bₚ = 10, E₀ = 200` to `Bₚ = 200, E₀ = 10`, Asymmetric
  from `Bₚ = 10, E₀ = 50` to `Bₚ = 50, E₀ = 10`. The constants were right and `init` was wrong, not
  the other way round — `DEFAULT_E₀ = 10.0` in all three Penning trap modules, and the swap was the
  only thing making the bottle and asymmetric traps disagree with `PenningTrapUniform` on the field
  strength.

* **`Solovev.FRC()` hung.** It had `R₀ = 0`, and `R₀` enters the metric as `g₁₁ = g₂₂ = R₀²`, so
  `inv(gmat)` is singular and `generate_equilibrium_functions` never returned. Now `R₀ = 1`: in
  Cerfon & Freidberg (*Phys. Plasmas* **17**, 032502, 2010), the paper this module already cites,
  Eq. (3) normalises `R = R₀x`, `Z = R₀y` with `R₀` "the major radius of the plasma", and every
  figure is in `R/R₀`. `B₀ = 0` is deliberately left alone — Sec. VIII defines an FRC as having zero
  toroidal field, and `A₃ = ψ` does not involve `B₀`, so the poloidal field is untouched.

With FRC generating, `SolovevFRC` joins both testsets, which is where the 8381 → 8824 growth in the
structural check comes from.

## Verification

Independently of the structural testset, every equilibrium was generated twice — `cse = true` and
`cse = false` — into separate modules and compared with `isequal`, which is bit equality for floats
and distinguishes `±0.0`:

* all 6404 generated functions of the fourteen cheap equilibria, at four points: 25,516 evaluations,
  no mismatch;
* a 98-function selection of the five Solov'ev variants including `db₁dx₁` and `d²b₁dx₁dx₁`, at four
  points: 1960 evaluations, no mismatch;
* all 460 functions of the newly enabled `SolovevFRC`, at four points: 1840 evaluations, no mismatch.

`SolovevFRC` also passes the full `@test_equilibrium` block at 291/291, the same count as every other
equilibrium — the field is finite, `ḡ ≈ inv(g)`, `DF'DF ≈ g`, `J ≈ sqrt(det(DF'DF))`, and the
`a`/`b`/`c` triads are orthonormal under both `g` and `ḡ`. `b₃ = 0` throughout, as it must be with no
toroidal field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

