### PR TITLE
Take the Hodge star's orientation from the signed Jacobian, and fix the regularised chart's A₂

### DIFF
--- a/src/analytic/analytic_equilibrium.jl
+++ b/src/analytic/analytic_equilibrium.jl
@@ -33,6 +33,30 @@ Several of the charts in this package are left-handed — `(R, Z, ϕ)` and `(r, 
 not a corner case. Getting it wrong reverses `B` without any other visible symptom: the same
 vector potential yields a magnetic field antiparallel to the one the cartesian chart gives at the
 same physical point.
+
+# Orientation of the charts in this package
+
+Every equilibrium built on `CartesianEquilibrium` uses the identity map `(x, y, z)`, so `DF = I`,
+`J = 1` and the chart is right-handed. The four families below define their own coordinates, and
+all four are left-handed — in each case because the toroidal angle `ϕ` sits in the third slot where
+the right-handed ordering would put the second poloidal coordinate.
+
+| chart | coordinates `(ξ¹, ξ², ξ³)` | `J` | `det DF` | orientation |
+|:--|:--|:--|:--|:--:|
+| `CartesianEquilibrium` and all its subtypes | `(x, y, z)` | `1` | `+1` | `+1` |
+| `AxisymmetricTokamakCylindrical` | `(R, Z, ϕ)` | `R` | `-R` | `-1` |
+| `AxisymmetricTokamakToroidal` | `(r, θ, ϕ)` | `r R` | `-r R` | `-1` |
+| `AxisymmetricTokamakToroidalRegularization` | `(r, θ, ϕ)` | `r R` | `-r R` | `-1` |
+| `AbstractSolovevEquilibrium` | `(R/R₀, Z/R₀, ϕ)` | `R R₀²` | `-R R₀²` | `-1` |
+
+Concretely: `AxisymmetricTokamakCartesian`, `SolovevSymmetric`, `ThetaPinch`, `Dipole`, `ABC`,
+`Singular`, `SymmetricQuadratic`, `QuadraticPotentials` and the three Penning traps are
+right-handed; `AxisymmetricTokamakCylindrical`, `AxisymmetricTokamakToroidal`,
+`AxisymmetricTokamakToroidalRegularization` and every `Solovev*` equilibrium other than
+`SolovevSymmetric` (which is a cartesian chart despite the name) are left-handed.
+
+`test_analytic.jl` asserts `det(DF) ≈ orientation(equ) * J` for each of them, so a new chart that
+declares the wrong sign fails immediately rather than silently flipping its own `B`.
 """
 orientation(::AnalyticField) = 1
 

--- a/src/analytic/analytic_equilibrium.jl
+++ b/src/analytic/analytic_equilibrium.jl
@@ -19,6 +19,23 @@ x³(::AbstractVector, ::ET) where {ET<:AnalyticField} = error("x³() not impleme
 
 J(::AbstractVector, ::ET) where {ET<:AnalyticField} = error("J() not implemented for ", ET)
 
+@doc raw"""
+    orientation(equ)
+
+Sign of the chart's orientation: `+1` if `(ξ¹, ξ², ξ³)` is right-handed, `-1` if left-handed.
+
+`J(x, equ)` is the *volume element* `√|g| = |det DF|`, which is what most of the machinery here
+wants and what `functions["J"]` exports. The Hodge star and the cross product, however, are
+orientation-dependent and need the *signed* determinant `det DF = orientation(equ) * J(x, equ)`.
+
+Several of the charts in this package are left-handed — `(R, Z, ϕ)` and `(r, θ, ϕ)` both have
+`det DF < 0`, since the right-handed orderings would be `(R, ϕ, Z)` and `(r, ϕ, θ)` — so this is
+not a corner case. Getting it wrong reverses `B` without any other visible symptom: the same
+vector potential yields a magnetic field antiparallel to the one the cartesian chart gives at the
+same physical point.
+"""
+orientation(::AnalyticField) = 1
+
 g₁₁(::AbstractVector{T}, ::AnalyticField) where {T} = one(T)
 g₁₂(::AbstractVector{T}, ::AnalyticField) where {T} = zero(T)
 g₁₃(::AbstractVector{T}, ::AnalyticField) where {T} = zero(T)
@@ -233,6 +250,11 @@ function generate_equilibrium_functions(equ::AnalyticEquilibrium, pert::Analytic
     Jdet = J(ξ, equ)
     symprint("J", Jdet, output, 2)
 
+    # Signed Jacobian determinant det(DF), for the orientation-dependent operations below. See
+    # `orientation`.
+    Jsgn = orientation(equ) * Jdet
+    symprint("det(DF)", Jsgn, output, 2)
+
     # obtain vector potential
     A¹ = A(ξ, equ) .+ A(ξ, pert)
     symprint("A¹", A¹, output, 2)
@@ -262,7 +284,7 @@ function generate_equilibrium_functions(equ::AnalyticEquilibrium, pert::Analytic
     symprint("B²", B², output, 2)
 
     # compute magnetic field one-form B¹ = ⋆B²
-    B¹ = [hodge²¹(B², ginv, Jdet, i) for i in 1:3]
+    B¹ = [hodge²¹(B², ginv, Jsgn, i) for i in 1:3]
     symprint("B¹", B¹, output, 2)
 
     # compute magnetic field in physical coordinates
@@ -318,12 +340,12 @@ function generate_equilibrium_functions(equ::AnalyticEquilibrium, pert::Analytic
     for tvec ∈ ([Basic(1), Basic(0), Basic(0)],
         [Basic(0), Basic(1), Basic(0)],
         [Basic(0), Basic(0), Basic(1)])
-        avec .= [crossproduct(tvec, bvec, ginv, Jdet, i) for i in 1:3]
+        avec .= [crossproduct(tvec, bvec, ginv, Jsgn, i) for i in 1:3]
         if avec != [Basic(0), Basic(0), Basic(0)]
             break
         end
     end
-    cvec = [crossproduct(bvec, avec, ginv, Jdet, i) for i in 1:3]
+    cvec = [crossproduct(bvec, avec, ginv, Jsgn, i) for i in 1:3]
 
     normalize!(avec, gmat)
     normalize!(cvec, gmat)

--- a/src/analytic/axisymmetric_tokamak_cylindrical.jl
+++ b/src/analytic/axisymmetric_tokamak_cylindrical.jl
@@ -2,11 +2,11 @@
 Axisymmetric tokamak equilibrium in (R,Z,ϕ) coordinates with covariant
 components of the vector potential given by
 ```math
-A (R, Z, \phi) = \frac{B_0}{2} \, \bigg( R_0 \, \frac{Z}{R} , \, - R_0 \, \ln \bigg( \frac{R}{R_0} \bigg) , \, - \frac{r^2}{q_0} \bigg)^T ,
+A (R, Z, \phi) = \frac{B_0}{2} \, \bigg( R_0 \, \frac{Z}{R} , \, - R_0 \, \ln \bigg( \frac{R}{R_0} \bigg) , \, + \frac{r^2}{q_0} \bigg)^T ,
 ```
 resulting in the magnetic field with covariant components
 ```math
-B (R, Z, \phi) = \frac{B_0}{q_0} \, \bigg( - \frac{Z}{R} , \, \frac{R - R_0}{R} , \, - q_0 R_0 \bigg)^T ,
+B (R, Z, \phi) = \frac{B_0}{q_0} \, \bigg( - \frac{Z}{R} , \, \frac{R - R_0}{R} , \, + q_0 R_0 \bigg)^T ,
 ```
 where $r = \sqrt{ (R - R_0)^2 + Z^2 }$.
 
@@ -83,6 +83,9 @@ Y(x::AbstractVector, equ::AxisymmetricTokamakCylindricalEquilibrium) = R(x, equ)
 θ(x::AbstractVector, equ::AxisymmetricTokamakCylindricalEquilibrium) = atan(Z(x, equ), R(x, equ) - equ.R₀)
 
 ElectromagneticFields.J(x::AbstractVector, equ::AxisymmetricTokamakCylindricalEquilibrium) = R(x, equ)
+# (R, Z, ϕ) is left-handed; the right-handed ordering would be (R, ϕ, Z). See `orientation`.
+ElectromagneticFields.orientation(::AxisymmetricTokamakCylindricalEquilibrium) = -1
+
 
 ElectromagneticFields.A₁(x::AbstractVector, equ::AxisymmetricTokamakCylindricalEquilibrium) = +equ.B₀ * equ.R₀ * Z(x, equ) / R(x, equ) / 2
 ElectromagneticFields.A₂(x::AbstractVector, equ::AxisymmetricTokamakCylindricalEquilibrium) = -equ.B₀ * equ.R₀ * log(R(x, equ) / equ.R₀) / 2

--- a/src/analytic/axisymmetric_tokamak_cylindrical.jl
+++ b/src/analytic/axisymmetric_tokamak_cylindrical.jl
@@ -86,7 +86,6 @@ ElectromagneticFields.J(x::AbstractVector, equ::AxisymmetricTokamakCylindricalEq
 # (R, Z, ϕ) is left-handed; the right-handed ordering would be (R, ϕ, Z). See `orientation`.
 ElectromagneticFields.orientation(::AxisymmetricTokamakCylindricalEquilibrium) = -1
 
-
 ElectromagneticFields.A₁(x::AbstractVector, equ::AxisymmetricTokamakCylindricalEquilibrium) = +equ.B₀ * equ.R₀ * Z(x, equ) / R(x, equ) / 2
 ElectromagneticFields.A₂(x::AbstractVector, equ::AxisymmetricTokamakCylindricalEquilibrium) = -equ.B₀ * equ.R₀ * log(R(x, equ) / equ.R₀) / 2
 ElectromagneticFields.A₃(x::AbstractVector, equ::AxisymmetricTokamakCylindricalEquilibrium) = +equ.B₀ * r²(x, equ) / equ.q₀ / 2

--- a/src/analytic/axisymmetric_tokamak_toroidal.jl
+++ b/src/analytic/axisymmetric_tokamak_toroidal.jl
@@ -2,13 +2,13 @@
 Axisymmetric tokamak equilibrium in (r,θ,ϕ) coordinates with covariant
 components of the vector potential given by
 ```math
-A (r, \theta, \phi) = B_0 \, \bigg( 0 , \, \frac{r R_0}{\cos (\theta)} - \bigg( \frac{R_0}{\cos (\theta)} \bigg)^2 \, \ln \bigg( \frac{R}{R_0} \bigg) , \, - \frac{r^2}{2 q_0} \bigg)^T ,
+A (r, \theta, \phi) = \frac{B_0 R_0}{2} \, \bigg( \frac{Z}{R} \cos (\theta) - \ln \bigg( \frac{R}{R_0} \bigg) \sin (\theta) , \, - r \, \bigg[ \frac{Z}{R} \sin (\theta) + \ln \bigg( \frac{R}{R_0} \bigg) \cos (\theta) \bigg] , \, + \frac{r^2}{q_0 R_0} \bigg)^T ,
 ```
 resulting in the magnetic field with covariant components
 ```math
 B (r, \theta, \phi) = \frac{B_0}{q_0} \, \bigg( 0 , \, \frac{r^2}{R}, \, q_0 R_0 \bigg)^T ,
 ```
-where $R = R_0 + r \cos \theta$.
+where $R = R_0 + r \cos \theta$ and $Z = r \sin \theta$.
 
 Parameters:
  * `R₀`: position of magnetic axis
@@ -84,7 +84,6 @@ Z(x::AbstractVector, equ::AxisymmetricTokamakToroidalEquilibrium) = r(x, equ) * 
 ElectromagneticFields.J(x::AbstractVector, equ::AxisymmetricTokamakToroidalEquilibrium) = r(x, equ) * R(x, equ)
 # (r, θ, ϕ) inherits the left-handed (R, Z, ϕ) orientation, since det ∂(R,Z)/∂(r,θ) = +r.
 ElectromagneticFields.orientation(::AxisymmetricTokamakToroidalEquilibrium) = -1
-
 
 ElectromagneticFields.A₁(x::AbstractVector, equ::AxisymmetricTokamakToroidalEquilibrium) = +equ.B₀ * equ.R₀ * (Z(x, equ) / R(x, equ) * cos(θ(x, equ)) - log(R(x, equ) / equ.R₀) * sin(θ(x, equ))) / 2
 ElectromagneticFields.A₂(x::AbstractVector, equ::AxisymmetricTokamakToroidalEquilibrium) = -equ.B₀ * equ.R₀ * (Z(x, equ) / R(x, equ) * sin(θ(x, equ)) + log(R(x, equ) / equ.R₀) * cos(θ(x, equ))) * r(x, equ) / 2

--- a/src/analytic/axisymmetric_tokamak_toroidal.jl
+++ b/src/analytic/axisymmetric_tokamak_toroidal.jl
@@ -82,6 +82,9 @@ Y(x::AbstractVector, equ::AxisymmetricTokamakToroidalEquilibrium) = R(x, equ) * 
 Z(x::AbstractVector, equ::AxisymmetricTokamakToroidalEquilibrium) = r(x, equ) * sin(θ(x, equ))
 
 ElectromagneticFields.J(x::AbstractVector, equ::AxisymmetricTokamakToroidalEquilibrium) = r(x, equ) * R(x, equ)
+# (r, θ, ϕ) inherits the left-handed (R, Z, ϕ) orientation, since det ∂(R,Z)/∂(r,θ) = +r.
+ElectromagneticFields.orientation(::AxisymmetricTokamakToroidalEquilibrium) = -1
+
 
 ElectromagneticFields.A₁(x::AbstractVector, equ::AxisymmetricTokamakToroidalEquilibrium) = +equ.B₀ * equ.R₀ * (Z(x, equ) / R(x, equ) * cos(θ(x, equ)) - log(R(x, equ) / equ.R₀) * sin(θ(x, equ))) / 2
 ElectromagneticFields.A₂(x::AbstractVector, equ::AxisymmetricTokamakToroidalEquilibrium) = -equ.B₀ * equ.R₀ * (Z(x, equ) / R(x, equ) * sin(θ(x, equ)) + log(R(x, equ) / equ.R₀) * cos(θ(x, equ))) * r(x, equ) / 2

--- a/src/analytic/axisymmetric_tokamak_toroidal_regularization.jl
+++ b/src/analytic/axisymmetric_tokamak_toroidal_regularization.jl
@@ -2,13 +2,16 @@
 Axisymmetric tokamak equilibrium in (r,θ,ϕ) coordinates with covariant
 components of the vector potential given by
 ```math
-A (r, \theta, \phi) = B_0 \, \bigg( 0 , \, \frac{r R_0}{\cos (\theta)} - \bigg( \frac{R_0}{\cos (\theta)} \bigg)^2 \, \ln \bigg( \frac{R}{R_0} \bigg) , \, - \frac{r^2}{2 q_0} \bigg)^T ,
+A (r, \theta, \phi) = B_0 \, \bigg( 0 , \, \bigg( \frac{R_0}{\cos (\theta)} \bigg)^2 \, \ln \bigg( \frac{R}{R_0} \bigg) - \frac{r R_0}{\cos (\theta)} , \, + \frac{r^2}{2 q_0} \bigg)^T ,
 ```
 resulting in the magnetic field with covariant components
 ```math
 B (r, \theta, \phi) = \frac{B_0}{q_0} \, \bigg( 0 , \, \frac{r^2}{R}, \, q_0 R_0 \bigg)^T ,
 ```
 where $R = R_0 + r \cos \theta$.
+
+This is the same magnetic field as [`AxisymmetricTokamakToroidal`](@ref), in a gauge whose
+poloidal vector potential is regular on the magnetic axis.
 
 Parameters:
  * `R₀`: position of magnetic axis
@@ -70,9 +73,8 @@ ElectromagneticFields.J(x::AbstractVector, equ::AxisymmetricTokamakToroidalRegul
 # As for the unregularised toroidal chart.
 ElectromagneticFields.orientation(::AxisymmetricTokamakToroidalRegularizationEquilibrium) = -1
 
-
 ElectromagneticFields.A₁(x::AbstractVector, equ::AxisymmetricTokamakToroidalRegularizationEquilibrium) = zero(eltype(x))
-ElectromagneticFields.A₂(x::AbstractVector, equ::AxisymmetricTokamakToroidalRegularizationEquilibrium) = +equ.B₀ * equ.R₀ / cos(θ(x, equ))^2 * (r(x, equ) * cos(θ(x, equ)) - equ.R₀ * log(R(x, equ) / equ.R₀))
+ElectromagneticFields.A₂(x::AbstractVector, equ::AxisymmetricTokamakToroidalRegularizationEquilibrium) = -equ.B₀ * equ.R₀ / cos(θ(x, equ))^2 * (r(x, equ) * cos(θ(x, equ)) - equ.R₀ * log(R(x, equ) / equ.R₀))
 ElectromagneticFields.A₃(x::AbstractVector, equ::AxisymmetricTokamakToroidalRegularizationEquilibrium) = +equ.B₀ * r(x, equ)^2 / equ.q₀ / 2
 
 ElectromagneticFields.x¹(ξ::AbstractVector, equ::AxisymmetricTokamakToroidalRegularizationEquilibrium) = X(ξ, equ)

--- a/src/analytic/axisymmetric_tokamak_toroidal_regularization.jl
+++ b/src/analytic/axisymmetric_tokamak_toroidal_regularization.jl
@@ -67,6 +67,9 @@ Y(x::AbstractVector, equ::AxisymmetricTokamakToroidalRegularizationEquilibrium) 
 Z(x::AbstractVector, equ::AxisymmetricTokamakToroidalRegularizationEquilibrium) = r(x, equ) * sin(θ(x, equ))
 
 ElectromagneticFields.J(x::AbstractVector, equ::AxisymmetricTokamakToroidalRegularizationEquilibrium) = r(x, equ) * R(x, equ)
+# As for the unregularised toroidal chart.
+ElectromagneticFields.orientation(::AxisymmetricTokamakToroidalRegularizationEquilibrium) = -1
+
 
 ElectromagneticFields.A₁(x::AbstractVector, equ::AxisymmetricTokamakToroidalRegularizationEquilibrium) = zero(eltype(x))
 ElectromagneticFields.A₂(x::AbstractVector, equ::AxisymmetricTokamakToroidalRegularizationEquilibrium) = +equ.B₀ * equ.R₀ / cos(θ(x, equ))^2 * (r(x, equ) * cos(θ(x, equ)) - equ.R₀ * log(R(x, equ) / equ.R₀))

--- a/src/analytic/solovev_abstract.jl
+++ b/src/analytic/solovev_abstract.jl
@@ -22,6 +22,9 @@ r²(x::AbstractVector, equ::AbstractSolovevEquilibrium) = (R(x, equ) - equ.R₀)
 r(x::AbstractVector, equ::AbstractSolovevEquilibrium) = sqrt(r²(x, equ))
 
 ElectromagneticFields.J(x::AbstractVector, equ::AbstractSolovevEquilibrium) = R(x, equ) * equ.R₀^2
+# (R/R₀, Z/R₀, ϕ) is the same left-handed ordering as the cylindrical chart.
+ElectromagneticFields.orientation(::AbstractSolovevEquilibrium) = -1
+
 
 ElectromagneticFields.A₁(x::AbstractVector, equ::AbstractSolovevEquilibrium) = +equ.B₀ * equ.R₀ * x[2] / x[1] / 2
 ElectromagneticFields.A₂(x::AbstractVector, equ::AbstractSolovevEquilibrium) = -equ.B₀ * equ.R₀ * log(x[1]) / 2

--- a/src/analytic/solovev_abstract.jl
+++ b/src/analytic/solovev_abstract.jl
@@ -25,7 +25,6 @@ ElectromagneticFields.J(x::AbstractVector, equ::AbstractSolovevEquilibrium) = R(
 # (R/R₀, Z/R₀, ϕ) is the same left-handed ordering as the cylindrical chart.
 ElectromagneticFields.orientation(::AbstractSolovevEquilibrium) = -1
 
-
 ElectromagneticFields.A₁(x::AbstractVector, equ::AbstractSolovevEquilibrium) = +equ.B₀ * equ.R₀ * x[2] / x[1] / 2
 ElectromagneticFields.A₂(x::AbstractVector, equ::AbstractSolovevEquilibrium) = -equ.B₀ * equ.R₀ * log(x[1]) / 2
 

--- a/test/test_analytic.jl
+++ b/test/test_analytic.jl
@@ -33,6 +33,45 @@ macro test_equilibrium(equilibrium_module, equilibrium_rangemin, equilibrium_ran
         # inject code
         $equilibrium_module.@code
 
+        # The equilibrium object itself, for the traits that are not part of the generated code.
+        const equ = $equilibrium_module.init()
+
+        """
+        `A` in cartesian components, as a function of a cartesian point.
+
+        `A₁, A₂, A₃` are the covariant components in the chart's own coordinates; `DF̄[j,i] =
+        ∂ξⱼ/∂xᵢ` pulls them back onto the cartesian frame, which is orthonormal, so the result is
+        both the covariant and the contravariant cartesian representation.
+        """
+        function A_cartesian(t, x)
+            η = from_cartesian(t, x)
+            Aη = [A₁(t, η...), A₂(t, η...), A₃(t, η...)]
+            D = DF̄(t, η)
+            [D[1, i] * Aη[1] + D[2, i] * Aη[2] + D[3, i] * Aη[3] for i in 1:3]
+        end
+
+        """
+        `B = ∇ × A`, checked in cartesian coordinates.
+
+        This is the one statement about the magnetic field that does not depend on the chart, so it
+        is the check that catches an orientation error: a left-handed chart whose Hodge star is
+        handed `|det DF|` instead of `det DF` produces a `B` that is exactly antiparallel to the
+        curl of its own vector potential, and nothing else in this file notices.
+        """
+        function test_curl(t, ξ; h=1E-5)
+            x = to_cartesian(t, ξ)
+            ê(i) = [k == i ? one(eltype(x)) : zero(eltype(x)) for k in 1:3]
+            ∂(i, j) = (A_cartesian(t, x .+ h .* ê(i))[j] -
+                       A_cartesian(t, x .- h .* ê(i))[j]) / (2h)
+
+            curlA = [∂(2, 3) - ∂(3, 2), ∂(3, 1) - ∂(1, 3), ∂(1, 2) - ∂(2, 1)]
+            Bcar = [B₍₁₎(t, ξ...), B₍₂₎(t, ξ...), B₍₃₎(t, ξ...)]
+
+            # central differences on an O(1) field carry an O(h²) truncation error; the tolerance is
+            # scaled by |B| so that it means the same thing for the Dipole as for the ThetaPinch
+            @test norm(curlA - Bcar) ≤ 1E-6 * max(norm(Bcar), 1)
+        end
+
         function test_equilibrium(t, ξ)
             @test ξ¹(t, ξ...) == ξ¹(t, ξ)
             @test ξ²(t, ξ...) == ξ²(t, ξ)
@@ -357,6 +396,13 @@ macro test_equilibrium(equilibrium_module, equilibrium_rangemin, equilibrium_ran
                 â = aₚ(t, ξ), b̂ = bₚ(t, ξ), ĉ = cₚ(t, ξ)
 
                 @test J(t, ξ) ≈ sqrt(det(DF' * DF)) atol = 1E-12
+
+                # `J` is the unsigned volume element |det DF|, asserted just above. `orientation`
+                # carries the sign that `J` throws away, and the two together must reproduce the
+                # signed determinant — otherwise the Hodge star and the cross product, which are
+                # handed `orientation(equ) * J`, are working in the wrong-handed frame.
+                @test det(DF) ≈ ElectromagneticFields.orientation(equ) * J(t, ξ) atol = 1E-12
+                @test ElectromagneticFields.orientation(equ) ∈ (-1, +1)
                 @test ḡ ≈ inv(g) atol = 1E-12
                 @test DF̄ ≈ inv(DF) atol = 1E-12
                 @test DF' * DF ≈ g atol = 1E-12
@@ -417,6 +463,7 @@ macro test_equilibrium(equilibrium_module, equilibrium_rangemin, equilibrium_ran
         @testset "$(rpad($module_name,60))" begin
             import .$module_test
             $module_test.test_equilibrium(t, ξ)
+            $module_test.test_curl(t, ξ)
         end
     end
 end
@@ -495,6 +542,22 @@ function test_axisymmetric_tokamak_toroidal_equilibrium(equ_mod, t=0.0, x=[0.5, 
 
     @test equ_mod.B₁(t, x) == 0
     @test equ_mod.B₂(t, x) == +equ_mod.B₀ / equ_mod.q₀ * equ_mod.r(t, x)^2 / equ_mod.R(t, x)
+    @test equ_mod.B₃(t, x) ≈ +equ_mod.B₀ * equ_mod.R₀ atol = 1E-14
+end
+
+"""
+The regularised chart carries the same magnetic field as `AxisymmetricTokamakToroidal`, in a gauge
+whose poloidal vector potential is regular on the magnetic axis, so it must reproduce that chart's
+field values exactly. Only the tolerances differ: the `1/cos²θ` gauge makes the generated
+expressions less well conditioned, so these are approximate where the unregularised ones are exact.
+"""
+function test_axisymmetric_tokamak_toroidal_regularization_equilibrium(equ_mod, t=0.0, x=[0.5, π / 10, π / 5])
+    @test equ_mod.B¹(t, x) ≈ 0 atol = 1E-14
+    @test equ_mod.B²(t, x) ≈ +equ_mod.B₀ / equ_mod.q₀ / equ_mod.R(t, x) atol = 1E-14
+    @test equ_mod.B³(t, x) ≈ +equ_mod.B₀ * equ_mod.R₀ / equ_mod.R(t, x)^2 atol = 1E-14
+
+    @test equ_mod.B₁(t, x) ≈ 0 atol = 1E-14
+    @test equ_mod.B₂(t, x) ≈ +equ_mod.B₀ / equ_mod.q₀ * equ_mod.r(t, x)^2 / equ_mod.R(t, x) atol = 1E-14
     @test equ_mod.B₃(t, x) ≈ +equ_mod.B₀ * equ_mod.R₀ atol = 1E-14
 end
 
@@ -588,6 +651,7 @@ end
     test_axisymmetric_tokamak_cartesian_equilibrium(AxisymmetricTokamakCartesianTest)
     test_axisymmetric_tokamak_cylindrical_equilibrium(AxisymmetricTokamakCylindricalTest)
     test_axisymmetric_tokamak_toroidal_equilibrium(AxisymmetricTokamakToroidalTest)
+    test_axisymmetric_tokamak_toroidal_regularization_equilibrium(AxisymmetricTokamakToroidalRegularizationTest)
     test_symmetric_quadratic_equilibrium(SymmetricQuadraticTest)
     test_theta_pinch_equilibrium(ThetaPinchTest)
     test_abc_equilibrium(ABCTest)
@@ -596,6 +660,8 @@ end
 @testset "$(rpad("Consistency",60))" begin
     test_consistency_axisymmetric_tokamak_cylindrical_equilibrium(AxisymmetricTokamakCylindricalTest, AxisymmetricTokamakCartesianTest)
     test_consistency_axisymmetric_tokamak_toroidal_equilibrium(AxisymmetricTokamakToroidalTest, AxisymmetricTokamakCartesianTest)
+    # the regularised chart shares the toroidal chart's coordinates, so the same check applies
+    test_consistency_axisymmetric_tokamak_toroidal_equilibrium(AxisymmetricTokamakToroidalRegularizationTest, AxisymmetricTokamakCartesianTest)
 end
 
 

--- a/test/test_analytic.jl
+++ b/test/test_analytic.jl
@@ -479,23 +479,23 @@ function test_axisymmetric_tokamak_cartesian_equilibrium(equ_mod, t=0.0, x=[1.5,
 end
 
 function test_axisymmetric_tokamak_cylindrical_equilibrium(equ_mod, t=0.0, x=[1.5, 0.5, π / 5])
-    @test equ_mod.B¹(t, x) == +equ_mod.B₀ / equ_mod.q₀ * equ_mod.Z(t, x) / equ_mod.R(t, x)
-    @test equ_mod.B²(t, x) == -equ_mod.B₀ / equ_mod.q₀ * (equ_mod.R(t, x) - equ_mod.R₀) / equ_mod.R(t, x)
-    @test equ_mod.B³(t, x) == -equ_mod.B₀ * equ_mod.R₀ / equ_mod.R(t, x)^2
+    @test equ_mod.B¹(t, x) == -equ_mod.B₀ / equ_mod.q₀ * equ_mod.Z(t, x) / equ_mod.R(t, x)
+    @test equ_mod.B²(t, x) == +equ_mod.B₀ / equ_mod.q₀ * (equ_mod.R(t, x) - equ_mod.R₀) / equ_mod.R(t, x)
+    @test equ_mod.B³(t, x) == +equ_mod.B₀ * equ_mod.R₀ / equ_mod.R(t, x)^2
 
-    @test equ_mod.B₁(t, x) == +equ_mod.B₀ / equ_mod.q₀ * equ_mod.Z(t, x) / equ_mod.R(t, x)
-    @test equ_mod.B₂(t, x) == -equ_mod.B₀ / equ_mod.q₀ * (equ_mod.R(t, x) - equ_mod.R₀) / equ_mod.R(t, x)
-    @test equ_mod.B₃(t, x) == -equ_mod.B₀ * equ_mod.R₀
+    @test equ_mod.B₁(t, x) == -equ_mod.B₀ / equ_mod.q₀ * equ_mod.Z(t, x) / equ_mod.R(t, x)
+    @test equ_mod.B₂(t, x) == +equ_mod.B₀ / equ_mod.q₀ * (equ_mod.R(t, x) - equ_mod.R₀) / equ_mod.R(t, x)
+    @test equ_mod.B₃(t, x) == +equ_mod.B₀ * equ_mod.R₀
 end
 
 function test_axisymmetric_tokamak_toroidal_equilibrium(equ_mod, t=0.0, x=[0.5, π / 10, π / 5])
     @test equ_mod.B¹(t, x) == 0
-    @test equ_mod.B²(t, x) == -equ_mod.B₀ / equ_mod.q₀ / equ_mod.R(t, x)
-    @test equ_mod.B³(t, x) ≈ -equ_mod.B₀ * equ_mod.R₀ / equ_mod.R(t, x)^2 atol = 1E-14
+    @test equ_mod.B²(t, x) == +equ_mod.B₀ / equ_mod.q₀ / equ_mod.R(t, x)
+    @test equ_mod.B³(t, x) ≈ +equ_mod.B₀ * equ_mod.R₀ / equ_mod.R(t, x)^2 atol = 1E-14
 
     @test equ_mod.B₁(t, x) == 0
-    @test equ_mod.B₂(t, x) == -equ_mod.B₀ / equ_mod.q₀ * equ_mod.r(t, x)^2 / equ_mod.R(t, x)
-    @test equ_mod.B₃(t, x) ≈ -equ_mod.B₀ * equ_mod.R₀ atol = 1E-14
+    @test equ_mod.B₂(t, x) == +equ_mod.B₀ / equ_mod.q₀ * equ_mod.r(t, x)^2 / equ_mod.R(t, x)
+    @test equ_mod.B₃(t, x) ≈ +equ_mod.B₀ * equ_mod.R₀ atol = 1E-14
 end
 
 function test_consistency_axisymmetric_tokamak_cylindrical_equilibrium(equ_cyl, equ_car, t=0.0, ξ=[1.5, 0.5, π / 5])
@@ -510,8 +510,8 @@ function test_consistency_axisymmetric_tokamak_cylindrical_equilibrium(equ_cyl, 
     B̂_car = [equ_car.B₁(t, x), equ_car.B₂(t, x), equ_car.B₃(t, x)]
 
     @test B_cyl' * B̂_cyl ≈ B_car' * B̂_car atol = 1E-12
-    @test DF * B_cyl ≈ -B_car atol = 1E-12
-    @test DF̄' * B̂_cyl ≈ -B̂_car atol = 1E-12
+    @test DF * B_cyl ≈ B_car atol = 1E-12
+    @test DF̄' * B̂_cyl ≈ B̂_car atol = 1E-12
 end
 
 function test_consistency_axisymmetric_tokamak_toroidal_equilibrium(equ_tor, equ_car, t=0.0, ξ=[0.5, π / 10, π / 5])
@@ -526,8 +526,8 @@ function test_consistency_axisymmetric_tokamak_toroidal_equilibrium(equ_tor, equ
     B̂_car = [equ_car.B₁(t, x), equ_car.B₂(t, x), equ_car.B₃(t, x)]
 
     @test B_tor' * B̂_tor ≈ B_car' * B̂_car atol = 1E-12
-    @test DF * B_tor ≈ -B_car atol = 1E-12
-    @test DF̄' * B̂_tor ≈ -B̂_car atol = 1E-12
+    @test DF * B_tor ≈ B_car atol = 1E-12
+    @test DF̄' * B̂_tor ≈ B̂_car atol = 1E-12
 end
 
 function test_symmetric_quadratic_equilibrium(equ_mod, t=0.0, x=[1.0, 0.5, 0.5])


### PR DESCRIPTION
## The defect

`B¹ = ⋆dA` is orientation-dependent, and `hodge²¹` was being handed `J(x, equ)` — the **unsigned** volume element `√|g| = |det DF|`. Four of the charts here are left-handed: `(R, Z, ϕ)` and `(r, θ, ϕ)` both have `det DF < 0`, the right-handed orderings being `(R, ϕ, Z)` and `(r, ϕ, θ)`. In every one of them the magnetic field came out **reversed** — the same vector potential produced a `B` antiparallel to the one the cartesian chart gives at the same physical point.

## Evidence

The cartesian chart is unambiguous (`J = 1`, Euclidean), and its vector potential transforms *exactly* onto the cylindrical one:

- `A_R = A_x cos ϕ + A_y sin ϕ = B₀R₀Z/2R`
- `A_Z = A_z = −B₀R₀ln(R/R₀)/2`
- `A_φ = −A_x R sin ϕ + A_y R cos ϕ = B₀r²/2q₀`

All three match the cylindrical chart's declared `A`. Since `A` is the same vector field, `B = ∇×A` must be too. At `x = (1.05, 0, 0)` with `(R₀, B₀, q₀) = (1, 1, 2)`, before this change:

| chart | physical `b`, in cartesian components |
|---|---|
| cartesian | `(0, +0.999688, +0.024992)` |
| cylindrical | `(0, −0.999688, −0.024992)` |
| toroidal | `(0, −0.999688, −0.024992)` |

Afterwards all three agree to machine precision.

Two independent confirmations that the code, not the fix, was wrong:

1. The **toroidal docstring** already states `B = (B₀/q₀)(0, r²/R, +q₀R₀)` — exactly the values this change produces.
2. The cartesian/cylindrical and cartesian/toroidal consistency checks in `test_analytic.jl` asserted `DF * B_cyl ≈ **−**B_car`. The antiparallel field had been observed and written into the test rather than fixed.

## The fix

`J` keeps its meaning and its value — it is the volume element, it is what `functions["J"]` exports, and `test_analytic.jl` still asserts `J ≈ sqrt(det(DF'DF))`. Orientation is a separate property, so it becomes a separate trait:

```julia
orientation(::AnalyticField) = 1        # +1 right-handed, -1 left-handed
```

declared `-1` for the four left-handed charts. Only the two orientation-dependent operations — the Hodge star and the cross product — use the signed determinant `orientation(equ) * J(x, equ)`.

## A second chart that disagreed

Re-running the same consistency check across the rest of the package turned up one more defect, independent of the Hodge star and older than it.

`AxisymmetricTokamakToroidalRegularization` carried the **wrong sign on `A₂`**. Its poloidal field — which comes from `A₃` — matched the cartesian chart all along, but its toroidal field was antiparallel:

| chart | `B_R` | `B_ϕ` | `B_Z` |
|---|---|---|---|
| cartesian | −0.0728601 | **+0.8571778** | +0.0714111 |
| toroidal | −0.0728601 | **+0.8571778** | +0.0714111 |
| toroidal-regularization | −0.0728601 | **−0.8571778** | +0.0714111 |

The chart was internally consistent — it satisfies `B = ∇×A` for its own `A` to 8e-12 — which is why the orientation work did not surface it. It was *wrong*, not *inconsistent*. With the sign corrected, all four axisymmetric tokamak charts now agree to twelve digits, and the docstring's claim that this is the same field as `AxisymmetricTokamakToroidal` in an axis-regular gauge is finally true.

## Tests

The cylindrical and toroidal field-value assertions encoded the reversed field and are corrected; the cartesian ones, self-consistent throughout, are untouched. The two consistency checks lose their explicit minus and thereby become the guard against a regression.

Three additions, each verified by reintroducing the defect it targets:

- **`test_curl`** checks `B = ∇×A` in cartesian coordinates for all twenty equilibria, pulling each chart's covariant `A` onto the cartesian frame with `DF̄` and central-differencing. This is the only statement about `B` that does not depend on the chart, so it is the one that catches an orientation error. Handing `hodge²¹` the unsigned `|det DF|` again fails it on the first left-handed chart.
- **`det(DF) ≈ orientation(equ) * J`** sits beside the existing `J ≈ sqrt(det(DF'DF))`. That one pins `J` to the unsigned volume element; this one pins `orientation` to the sign `J` discards, so a new chart that declares the wrong handedness fails rather than silently reversing its `B`.
- The **regularised chart** gains field-value assertions and the toroidal/cartesian consistency check, which applies verbatim since it shares those coordinates. `test_curl` passes the `A₂` defect, as it should; these are what catch it.

Counts go from 291 to 294 per equilibrium, Magnetic Fields 53 → 59, Consistency 6 → 9.

## Docstrings

- The **toroidal** chart's `A` was the regularised variant's formula, wrong in all three components; replaced with the one the code implements.
- Both toroidal charts stated `A₃ = −B₀r²/2q₀` where the code has `+` — the same defect already fixed in the cylindrical chart.
- The cylindrical docstring's `A₃` sign disagreed with its own code and its `B₃` with the corrected field; both are brought into line.

All eighteen component claims across the three charts are now checked against the generated code.

## Chart handedness

`orientation` gains a table of every chart's handedness:

| chart | coordinates | `J` | `det DF` | orientation |
|:--|:--|:--|:--|:--:|
| `CartesianEquilibrium` and all subtypes | `(x, y, z)` | `1` | `+1` | **+1** |
| `AxisymmetricTokamakCylindrical` | `(R, Z, ϕ)` | `R` | `-R` | **−1** |
| `AxisymmetricTokamakToroidal` | `(r, θ, ϕ)` | `r R` | `-r R` | **−1** |
| `AxisymmetricTokamakToroidalRegularization` | `(r, θ, ϕ)` | `r R` | `-r R` | **−1** |
| `AbstractSolovevEquilibrium` | `(R/R₀, Z/R₀, ϕ)` | `R R₀²` | `-R R₀²` | **−1** |

In each left-handed case the cause is the same: `ϕ` sits in the third slot where the right-handed ordering wants the second poloidal coordinate. `SolovevSymmetric` is the one to watch — despite the name it is a cartesian chart, and so right-handed, unlike every other `Solovev*` equilibrium.

## Impact

Affects `AxisymmetricTokamakCylindrical`, `AxisymmetricTokamakToroidal`, `AxisymmetricTokamakToroidalRegularization` and **every Solovev equilibrium except `SolovevSymmetric`**, which is a cartesian chart. Downstream results computed in these charts will change sign in `B`; `AxisymmetricTokamakToroidalRegularization` additionally changes sign in its toroidal component only. The cartesian charts are unaffected.

**This is a breaking change** and warrants a minor version bump before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
