### PR TITLE
Emit `orientation` into the generated code

### DIFF
--- a/src/analytic/analytic_equilibrium.jl
+++ b/src/analytic/analytic_equilibrium.jl
@@ -57,6 +57,10 @@ right-handed; `AxisymmetricTokamakCylindrical`, `AxisymmetricTokamakToroidal`,
 
 `test_analytic.jl` asserts `det(DF) ≈ orientation(equ) * J` for each of them, so a new chart that
 declares the wrong sign fails immediately rather than silently flipping its own `B`.
+
+[`code`](@ref) emits a zero-argument `orientation()` into the generated module — the one generated
+function that takes no arguments, since the sign depends on neither `t` nor `ξ` — so a loaded
+equilibrium can recover `det DF = orientation() * J(t, ξ)` without the equilibrium object.
 """
 orientation(::AnalyticField) = 1
 
@@ -839,6 +843,17 @@ function code(equ, pert=ZeroPerturbation(); export_parameters=true, escape=false
         $(fnesc(:rangemax, escape))(ξ) = $(fnesc(:rangemax, escape))(0, ξ)
         $(fnesc(:rangemin, escape))(ξ₁, ξ₂, ξ₃) = $(fnesc(:rangemin, escape))(0, ξ₁, ξ₂, ξ₃)
         $(fnesc(:rangemax, escape))(ξ₁, ξ₂, ξ₃) = $(fnesc(:rangemax, escape))(0, ξ₁, ξ₂, ξ₃)
+    end
+
+    # append f_code to equ_code
+    append!(equ_code.args, f_code.args)
+
+    # The chart's orientation. Unlike every other generated function this one takes no arguments:
+    # it is a property of the chart, constant in both t and ξ. See
+    # `ElectromagneticFields.orientation`.
+    f_code = quote
+        export $(fnesc(:orientation, escape))
+        $(fnesc(:orientation, escape))() = $(orientation(equ))
     end
 
     # append f_code to equ_code

--- a/src/analytic/analytic_equilibrium.jl
+++ b/src/analytic/analytic_equilibrium.jl
@@ -55,12 +55,14 @@ right-handed; `AxisymmetricTokamakCylindrical`, `AxisymmetricTokamakToroidal`,
 `AxisymmetricTokamakToroidalRegularization` and every `Solovev*` equilibrium other than
 `SolovevSymmetric` (which is a cartesian chart despite the name) are left-handed.
 
-`test_analytic.jl` asserts `det(DF) ≈ orientation(equ) * J` for each of them, so a new chart that
-declares the wrong sign fails immediately rather than silently flipping its own `B`.
-
 [`code`](@ref) emits a zero-argument `orientation()` into the generated module — the one generated
 function that takes no arguments, since the sign depends on neither `t` nor `ξ` — so a loaded
 equilibrium can recover `det DF = orientation() * J(t, ξ)` without the equilibrium object.
+
+`test_analytic.jl` asserts `det(DF) ≈ orientation() * J` for each of the charts above, reading the
+generated function, and separately that it equals the trait it was generated from. A new chart that
+declares the wrong sign therefore fails immediately rather than silently flipping its own `B`, and
+so does a generator that stops tracking the trait.
 """
 orientation(::AnalyticField) = 1
 
@@ -660,6 +662,10 @@ which `@code` splices into the calling module and [`load_equilibrium`](@ref) eva
 
 The `@code` macros take these as `key = value` arguments, after the equilibrium's parameters:
 `ThetaPinch.@code(B₀, cse = false)`, or just `ThetaPinch.@code cse = false` for the defaults.
+
+Every generated function takes `(t, ξ₁, ξ₂, ξ₃)` and `(t, ξ)`, except `orientation()`, which takes
+no arguments: it is the sign of the chart's handedness, constant in both `t` and `ξ`. See
+[`orientation`](@ref) for what it means and why `J` alone is not enough.
 """
 function code(equ, pert=ZeroPerturbation(); export_parameters=true, escape=false, output=0, cse=true)
 
@@ -851,6 +857,8 @@ function code(equ, pert=ZeroPerturbation(); export_parameters=true, escape=false
     # The chart's orientation. Unlike every other generated function this one takes no arguments:
     # it is a property of the chart, constant in both t and ξ. See
     # `ElectromagneticFields.orientation`.
+    output ≥ 1 ? println("Generating function orientation") : nothing
+
     f_code = quote
         export $(fnesc(:orientation, escape))
         $(fnesc(:orientation, escape))() = $(orientation(equ))

--- a/test/test_analytic.jl
+++ b/test/test_analytic.jl
@@ -668,6 +668,40 @@ end
 end
 
 
+# `code` has two callers with opposite `escape` settings, and everything above goes through only one
+# of them: `@test_equilibrium` splices `Mod.@code`, which escapes its names into the calling module.
+# `load_equilibrium` is the unescaped path, and it is the one that evaluates the generated `export`
+# statements into a module it does not own — so it is the path where `export orientation` can fail
+# without anything else noticing. Both handednesses are covered, since the sign is the whole point.
+
+using LinearAlgebra
+
+module AxisymmetricTokamakCylindricalLoadTest end
+module AxisymmetricTokamakCartesianLoadTest end
+
+const equ_cyl_loaded = ElectromagneticFields.AxisymmetricTokamakCylindrical.init()
+const equ_car_loaded = ElectromagneticFields.AxisymmetricTokamakCartesian.init()
+
+# at top level, so that the methods `load_equilibrium` evaluates are visible to the testset below —
+# calling it from inside `@testset` leaves them one world age too new to be called
+load_equilibrium(equ_cyl_loaded; target_module=AxisymmetricTokamakCylindricalLoadTest)
+load_equilibrium(equ_car_loaded; target_module=AxisymmetricTokamakCartesianLoadTest)
+
+@testset "$(rpad("load_equilibrium",60))" begin
+    for (target, equ) in (
+        (AxisymmetricTokamakCylindricalLoadTest, equ_cyl_loaded),
+        (AxisymmetricTokamakCartesianLoadTest, equ_car_loaded),
+    )
+        @test target.orientation() ∈ (-1, +1)
+        @test target.orientation() == ElectromagneticFields.orientation(equ)
+        @test det(target.DF(t, ξ)) ≈ target.orientation() * target.J(t, ξ) atol = 1E-12
+
+        # `names` sees only what the module exports, which is what the unescaped path emits
+        @test :orientation ∈ names(target)
+    end
+end
+
+
 # `code` runs every SymEngine-derived body through `eliminate_common_subexpressions`, which is only
 # safe because it names subexpressions rather than rewriting them. That claim is what is checked
 # here — that the eliminated block still denotes the very same expression — for every generated

--- a/test/test_analytic.jl
+++ b/test/test_analytic.jl
@@ -33,7 +33,8 @@ macro test_equilibrium(equilibrium_module, equilibrium_rangemin, equilibrium_ran
         # inject code
         $equilibrium_module.@code
 
-        # The equilibrium object itself, for the traits that are not part of the generated code.
+        # The equilibrium object itself, so that the generated `orientation()` can be checked
+        # against the trait it is generated from.
         const equ = $equilibrium_module.init()
 
         """
@@ -401,8 +402,10 @@ macro test_equilibrium(equilibrium_module, equilibrium_rangemin, equilibrium_ran
                 # carries the sign that `J` throws away, and the two together must reproduce the
                 # signed determinant — otherwise the Hodge star and the cross product, which are
                 # handed `orientation(equ) * J`, are working in the wrong-handed frame.
-                @test det(DF) ≈ ElectromagneticFields.orientation(equ) * J(t, ξ) atol = 1E-12
-                @test ElectromagneticFields.orientation(equ) ∈ (-1, +1)
+                @test det(DF) ≈ orientation() * J(t, ξ) atol = 1E-12
+                @test orientation() ∈ (-1, +1)
+                # the generated function must agree with the trait it was generated from
+                @test orientation() == ElectromagneticFields.orientation(equ)
                 @test ḡ ≈ inv(g) atol = 1E-12
                 @test DF̄ ≈ inv(DF) atol = 1E-12
                 @test DF' * DF ≈ g atol = 1E-12


### PR DESCRIPTION
## Context

`orientation(equ)` — `+1` for a right-handed chart, `-1` for a left-handed one — was introduced in #11 and is read at generation time to build `Jsgn = orientation(equ) * Jdet`, the signed determinant that the Hodge star and the cross product are handed. It was never emitted, though, so a loaded equilibrium could not recover the handedness of its own chart.

Every other scalar the generator knows is in the generated module: `J`, the metric, `DF`, the ranges, the parameters. Only the sign that `J` throws away was missing, and with it any way to reconstruct `det DF` from the generated module alone. `test_analytic.jl` already worked around this, keeping `const equ = init()` alive with the comment *"for the traits that are not part of the generated code"* purely so it could call `ElectromagneticFields.orientation(equ)`.

## Change

`code` now emits `orientation()` alongside the `rangemin`/`rangemax` wrappers.

It is the one generated function that takes no arguments: the sign depends on neither `t` nor `ξ`, so the usual `(t, ξ₁, ξ₂, ξ₃)` and `(t, ξ)` pair would be pure noise. The value is interpolated as a literal at generation time, so the body is `-1` or `1`. It goes through `fnesc` and carries its own `export` — the dict loop is what exports everything else — so both `Mod.@code` (escaped) and `load_equilibrium` (not) work.

`ElectromagneticFields.orientation` stays unexported, as `J` is: `load_equilibrium` evaluates `export orientation` into `Main` by default, and exporting the trait as well would collide there for anyone doing `using ElectromagneticFields`.

No per-equilibrium changes — the four `orientation(...) = -1` methods and the `AnalyticField` default are read as they are.

## Tests

The `det(DF) ≈ orientation * J` and `orientation ∈ (-1, +1)` assertions now read the generated function rather than the trait, and a third asserts the two agree, so a generator that stops tracking the trait fails rather than quietly reporting a stale sign. `const equ = init()` stays for that cross-check alone; its comment says so.

Full suite passes — all 20 equilibria (`295` assertions each, which exercise the escaped `@code` path) plus the CSE testset. Checked by hand on both handednesses through `load_equilibrium`:

```
cylindrical  orientation() = -1    det(DF) = -1.05   orientation()*J = -1.05
cartesian    orientation() = +1    det(DF) =  1.0    orientation()*J =  1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review follow-up

Four cleanups from the review, in `8543611`. The generated `orientation()` is unchanged and stays
nullary — the sign depends on neither `t` nor `ξ`, so forwarding `(t, ξ₁, ξ₂, ξ₃)` and `(t, ξ)`
methods would be noise. None of these is a correctness fix.

* **The `orientation` docstring still claimed the test asserts `det(DF) ≈ orientation(equ) * J`.**
  Copilot's comment, and it was right: the test reads the generated `orientation()` now and asserts
  agreement with the trait separately, so the claim was only transitively true and misdescribed how
  to reconstruct `det DF`.
* **`code`'s own docstring said nothing about it.** It documents the options and calls the result
  "the field functions of `equ`", so a user reading the generator — or `load_equilibrium` — had no
  way to discover `orientation()` exists, let alone that it is the one nullary generated name. Both
  docstrings are published; `docs/src/modules.md` is a bare `@autodocs`.
* **`output ≥ 1` did not report it.** The dict loop announces every name it emits, and the
  orientation block sits after that loop, so the generated-function list silently omitted it.
* **`load_equilibrium` had no test coverage at all** — `grep -rn load_equilibrium test/` returned
  nothing. The suite only went through `Mod.@code`, i.e. `escape = true`, leaving the branch that
  evaluates `export orientation` into a module it does not own uncovered. A testset now loads one
  left-handed and one right-handed equilibrium into throwaway modules and checks the sign, the trait
  agreement, `det(DF) ≈ orientation() * J`, and that `orientation` is actually exported.

One thing that came out of writing that testset and is worth knowing beyond this PR:
`load_equilibrium` cannot be called from inside a `@testset`. The methods it evaluates are one world
age too new to be called back from the enclosing body, which Julia 1.12+ raises as
`MethodError: no method matching orientation()` — "the applicable method may be too new". The calls
sit at top level with a comment saying so.

Verified locally: `Pkg.test()` exits 0 with the 20 equilibria unchanged at 295 assertions each
(`Singular` 262) and the new testset at 8; `code(...; output=1)` now ends with
`Generating function orientation`; `docs/make.jl` builds with both reworded docstrings rendering and
the new `@ref` resolving rather than dangling.
