### PR TITLE
Normalise the analytic equilibrium sources to NFC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,18 @@ not covered here; see the git history for those.
 - `src/analytic/analytic_equilibrium.jl` and `test/test_analytic.jl` are now Unicode
   NFC-normalised. They stored `ḡ` (21 times), `â` (3) and `ĉ` (3) as a base letter plus a combining
   mark, inherited from macOS rather than chosen, which makes no difference to the compiled code —
-  Julia's parser normalises
-  identifiers to NFC — but defeats every byte-matching tool: a `grep` pattern or an editor search
-  typed in NFC matches nothing in such a file, silently.
+  Julia's parser normalises identifiers to NFC — but defeats every byte-matching tool: a `grep`
+  pattern or an editor search typed in NFC matches nothing in such a file, silently.
+
+  Worth naming, because it is the hazard this removes: the file already spelled the same glyph
+  both ways. `functions["ḡ"]` was precomposed while the `ḡ` identifiers around it were decomposed,
+  and that worked only because the parser normalises the identifier side and not the string. No
+  non-NFC string literal remains under `src/`. `DF̄` is safe either way — a macron over `F` has no
+  precomposed codepoint.
+
+  A separate note for a reader of this file: `g̅` elsewhere in the same source is a *different*
+  binding, `g` plus a combining overline rather than a macron. It is unchanged, and
+  indistinguishable from `ḡ` on screen.
 
   The only bytes that change at runtime are the `"Dḡ"` and `"DDḡ"` labels passed to `symprint`,
   which prints them; string literals are not parser-normalised. Nothing reads that output back.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Releases 
 not covered here; see the git history for those.
 
 
+## [Unreleased]
+
+### Changed
+
+- `src/analytic/analytic_equilibrium.jl` and `test/test_analytic.jl` are now Unicode
+  NFC-normalised. They stored `ḡ` as a base letter plus a combining mark, inherited from macOS
+  rather than chosen, which makes no difference to the compiled code — Julia's parser normalises
+  identifiers to NFC — but defeats every byte-matching tool: a `grep` pattern or an editor search
+  typed in NFC matches nothing in such a file, silently.
+
+  The only bytes that change at runtime are the `"Dḡ"` and `"DDḡ"` labels passed to `symprint`,
+  which prints them; string literals are not parser-normalised. Nothing reads that output back.
+
 ## [0.8.0] - 2026-08-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ not covered here; see the git history for those.
 ### Changed
 
 - `src/analytic/analytic_equilibrium.jl` and `test/test_analytic.jl` are now Unicode
-  NFC-normalised. They stored `ḡ` as a base letter plus a combining mark, inherited from macOS
-  rather than chosen, which makes no difference to the compiled code — Julia's parser normalises
+  NFC-normalised. They stored `ḡ` (21 times), `â` (3) and `ĉ` (3) as a base letter plus a combining
+  mark, inherited from macOS rather than chosen, which makes no difference to the compiled code —
+  Julia's parser normalises
   identifiers to NFC — but defeats every byte-matching tool: a `grep` pattern or an editor search
   typed in NFC matches nothing in such a file, silently.
 

--- a/src/analytic/analytic_equilibrium.jl
+++ b/src/analytic/analytic_equilibrium.jl
@@ -282,14 +282,14 @@ function generate_equilibrium_functions(equ::AnalyticEquilibrium, pert::Analytic
     Dg = [diff(gmat[i, j], ξ[k]) for i in 1:3, j in 1:3, k in 1:3]
     symprint("Dg", Dg, output, 3)
 
-    Dḡ = [diff(ginv[i, j], ξ[k]) for i in 1:3, j in 1:3, k in 1:3]
-    symprint("Dḡ", Dḡ, output, 3)
+    Dḡ = [diff(ginv[i, j], ξ[k]) for i in 1:3, j in 1:3, k in 1:3]
+    symprint("Dḡ", Dḡ, output, 3)
 
     DDg = [diff(diff(gmat[i, j], ξ[k]), ξ[l]) for i in 1:3, j in 1:3, k in 1:3, l in 1:3]
     symprint("DDg", DDg, output, 3)
 
-    DDḡ = [diff(diff(ginv[i, j], ξ[k]), ξ[l]) for i in 1:3, j in 1:3, k in 1:3, l in 1:3]
-    symprint("DDḡ", DDḡ, output, 3)
+    DDḡ = [diff(diff(ginv[i, j], ξ[k]), ξ[l]) for i in 1:3, j in 1:3, k in 1:3, l in 1:3]
+    symprint("DDḡ", DDḡ, output, 3)
 
     # compute Jacobian determinant
     # Jdet² = expand(det(gmat))
@@ -506,11 +506,11 @@ function generate_equilibrium_functions(equ::AnalyticEquilibrium, pert::Analytic
                 functions["d²A" * indices[i] * "dx" * indices[j] * "dx" * indices[k]] = DDA[i, j, k]
                 functions["d²b" * indices[i] * "dx" * indices[j] * "dx" * indices[k]] = DDb[i, j, k]
                 functions["dg" * indices[i] * indices[j] * "dx" * indices[k]] = Dg[i, j, k]
-                functions["dg" * indicesup[i] * indicesup[j] * "dx" * indices[k]] = Dḡ[i, j, k]
+                functions["dg" * indicesup[i] * indicesup[j] * "dx" * indices[k]] = Dḡ[i, j, k]
                 for l in 1:3
                     functions["d²g" * indices[i] * indices[j] * "dx" * indices[k] * "dx" * indices[l]] = DDg[
                         i, j, k, l]
-                    functions["d²g" * indicesup[i] * indicesup[j] * "dx" * indices[k] * "dx" * indices[l]] = DDḡ[
+                    functions["d²g" * indicesup[i] * indicesup[j] * "dx" * indices[k] * "dx" * indices[l]] = DDḡ[
                         i, j, k, l]
                 end
             end

--- a/test/test_analytic.jl
+++ b/test/test_analytic.jl
@@ -409,9 +409,9 @@ macro test_equilibrium(equilibrium_module, equilibrium_rangemin, equilibrium_ran
                 @test @allocated(DF(t, ξ)) ≤ bound
             end
 
-            let g = g(t, ξ), ḡ = ḡ(t, ξ), DF = DF(t, ξ), DF̄ = DF̄(t, ξ), a = a(t, ξ),
+            let g = g(t, ξ), ḡ = ḡ(t, ξ), DF = DF(t, ξ), DF̄ = DF̄(t, ξ), a = a(t, ξ),
                 b = b(t, ξ), c = c(t, ξ), a⃗ = a⃗(t, ξ), b⃗ = b⃗(t, ξ), c⃗ = c⃗(t, ξ),
-                â = aₚ(t, ξ), b̂ = bₚ(t, ξ), ĉ = cₚ(t, ξ)
+                â = aₚ(t, ξ), b̂ = bₚ(t, ξ), ĉ = cₚ(t, ξ)
 
                 @test J(t, ξ) ≈ sqrt(det(DF' * DF)) atol = 1E-12
 
@@ -423,20 +423,20 @@ macro test_equilibrium(equilibrium_module, equilibrium_rangemin, equilibrium_ran
                 @test orientation() ∈ (-1, +1)
                 # the generated function must agree with the trait it was generated from
                 @test orientation() == ElectromagneticFields.orientation(equ)
-                @test ḡ ≈ inv(g) atol = 1E-12
+                @test ḡ ≈ inv(g) atol = 1E-12
                 @test DF̄ ≈ inv(DF) atol = 1E-12
                 @test DF' * DF ≈ g atol = 1E-12
                 @test DF * DF̄ ≈ Array(I, 3, 3) atol = 1E-12
-                @test DF̄ * DF̄' ≈ ḡ atol = 1E-12
+                @test DF̄ * DF̄' ≈ ḡ atol = 1E-12
 
                 if $equilibrium_module != ElectromagneticFields.Singular
                     @test g * a⃗ ≈ a atol = 1E-14
                     @test g * b⃗ ≈ b atol = 1E-14
                     @test g * c⃗ ≈ c atol = 1E-14
 
-                    @test ḡ * a ≈ a⃗ atol = 1E-14
-                    @test ḡ * b ≈ b⃗ atol = 1E-14
-                    @test ḡ * c ≈ c⃗ atol = 1E-14
+                    @test ḡ * a ≈ a⃗ atol = 1E-14
+                    @test ḡ * b ≈ b⃗ atol = 1E-14
+                    @test ḡ * c ≈ c⃗ atol = 1E-14
 
                     @test â ≈ DF * a⃗ atol = 1E-14
                     @test b̂ ≈ DF * b⃗ atol = 1E-14
@@ -454,17 +454,17 @@ macro test_equilibrium(equilibrium_module, equilibrium_rangemin, equilibrium_ran
                     @test b̂' * b̂ ≈ 1 atol = 1E-14
                     @test ĉ' * ĉ ≈ 1 atol = 1E-14
 
-                    @test â' * b̂ ≈ 0 atol = 1E-14
-                    @test b̂' * ĉ ≈ 0 atol = 1E-14
-                    @test ĉ' * â ≈ 0 atol = 1E-14
+                    @test â' * b̂ ≈ 0 atol = 1E-14
+                    @test b̂' * ĉ ≈ 0 atol = 1E-14
+                    @test ĉ' * â ≈ 0 atol = 1E-14
 
-                    @test a' * ḡ * a ≈ 1 atol = 1E-14
-                    @test b' * ḡ * b ≈ 1 atol = 1E-14
-                    @test c' * ḡ * c ≈ 1 atol = 1E-14
+                    @test a' * ḡ * a ≈ 1 atol = 1E-14
+                    @test b' * ḡ * b ≈ 1 atol = 1E-14
+                    @test c' * ḡ * c ≈ 1 atol = 1E-14
 
-                    @test a' * ḡ * b ≈ 0 atol = 1E-14
-                    @test b' * ḡ * c ≈ 0 atol = 1E-14
-                    @test c' * ḡ * a ≈ 0 atol = 1E-14
+                    @test a' * ḡ * b ≈ 0 atol = 1E-14
+                    @test b' * ḡ * c ≈ 0 atol = 1E-14
+                    @test c' * ḡ * a ≈ 0 atol = 1E-14
 
                     @test a⃗' * g * a⃗ ≈ 1 atol = 1E-14
                     @test b⃗' * g * b⃗ ≈ 1 atol = 1E-14


### PR DESCRIPTION
Converts `src/analytic/analytic_equilibrium.jl` and `test/test_analytic.jl` from NFD to Unicode NFC. They stored `ḡ` (21×), `â` (3×) and `ĉ` (3×) as a base letter plus a combining mark — an artefact of macOS, not a decision.

Part of a tree-wide conversion (`Tasks/Normalise the Julia sources to NFC.md`).

## Why, and the hazard this actually removes

Julia's parser normalises identifiers to NFC, so nothing about the compiled code changes. The cost of NFD is in tooling: a `grep` pattern or an editor search typed in NFC matches nothing in such a file, silently.

But this file had a sharper problem, worth naming because it is exactly the trap the conversion exists to close: **it already spelled the same glyph both ways.** `functions["ḡ"]` at `src/analytic/analytic_equilibrium.jl:824` was *precomposed* on `main`, while the `ḡ` identifiers around it were *decomposed*. That worked only because the parser normalises the identifier side and not the string side. Nothing was broken, but the two encodings were one careless edit apart from disagreeing.

After this branch, **zero non-NFC string literals remain under `src/`**.

`DF̄` is safe either way — a macron over `F` has no precomposed codepoint.

## The one runtime-visible change

`"Dḡ"` and `"DDḡ"` at `:286,292` are string literals, which are *not* parser-normalised, so their bytes change. They are labels passed to `symprint`, which only `println`s them (`:953`). Neither string occurs anywhere in `src/`, `test/` or `docs/`, so nothing reads that output back.

## Verification

| what | result |
|:--|:--|
| diff is exactly the NFC normalisation | 2/2 files |
| exhaustive `Expr`-leaf diff | **exactly two** differences, both the `symprint` labels |
| `test/test_analytic.jl` | `Expr`-identical |
| `Pkg.test()` | **30 testsets, 0 failed** (incl. 8824 CSE-preservation assertions) |
| no `functions[...]` Dict key is NFC-changing | proven by the exhaustiveness of the leaf diff |
| `fatou lint` | findings identical base vs head |

The leaf diff being *exhaustive* is what makes the Dict-key claim a proof rather than a sample: a changed key would have shown up as a third difference.

**Not applicable** rather than unmeasured: piracy, inference, allocations — apart from the two printed labels, base and head parse to identical trees.

## Pre-existing, deliberately not addressed

`src/analytic/analytic_equilibrium.jl` uses **two visually indistinguishable identifiers for the inverse metric**: `g̅` (`g` + combining overline, 15×, lines 141–206) and `ḡ` (`g` + macron, lines 285–513, 824). They are distinct bindings, always have been, and the tests are green — but nothing on screen tells a macron from an overline. Renaming one is a design decision and would falsify this branch's byte-equality claim, so it wants its own change.

Also: `unused-binding` at `:243` (`t` assigned, never used), 42 lines before the first hunk.
